### PR TITLE
fix: release workflow poetry setup and Node 24 opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ permissions:
 env:
   # Shared interpreter version for build and metadata steps.
   PYTHON_VERSION: "3.11"
+  # Opt in to Node.js 24 for JavaScript-based actions ahead of runner defaults.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   version-and-release:
@@ -100,15 +102,15 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
+      - name: Install Poetry
+        run: pipx install poetry
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
           cache-dependency-path: poetry.lock
-
-      - name: Install Poetry
-        run: pipx install poetry
 
       - name: Build distributions
         run: poetry build


### PR DESCRIPTION
- install Poetry before setup-python when using cache: poetry
- opt in to Node.js 24 for JS-based actions