### PR TITLE
Fix/workflow permissions

### DIFF
--- a/.github/vstack.json
+++ b/.github/vstack.json
@@ -1,6 +1,6 @@
 {
   "vstack_version": "0.0.0.post3.dev0+df3fe6e",
-  "installed_at": "2026-04-19T19:50:07.239266+00:00",
+  "installed_at": "2026-04-19T20:09:26.508121+00:00",
   "artifacts": {
     "skills": [
       {

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches-ignore: [main]
 
+permissions:
+  # Workflow only needs read access to repository contents.
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   POETRY_VIRTUALENVS_IN_PROJECT: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ on:
     branches: [main]
 
 permissions:
-  # Needed for creating tags and GitHub releases.
-  contents: write
+  # Default to read-only; release job elevates to write for tagging/releases.
+  contents: read
 
 env:
   # Shared interpreter version for build and metadata steps.
@@ -23,6 +23,9 @@ jobs:
     # Computes semantic version, creates git tag, and publishes GitHub release.
     name: Compute Version and Tag
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for creating tags and GitHub releases.
+      contents: write
     # Guard: run only for merged PRs.
     if: github.event.pull_request.merged == true
     outputs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  # Required by checkout and PR-context scanners.
+  contents: read
+  pull-requests: read
+
 env:
   # Keep scanner runtime consistent across runs.
   PYTHON_VERSION: "3.11"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,6 +7,10 @@ name: Verify
   pull_request:
     branches: [main]
 
+permissions:
+  # Verify jobs only read repository contents.
+  contents: read
+
 env:
   # Shared interpreter version for reproducible CI behavior.
   PYTHON_VERSION: "3.11"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,7 +2,7 @@
 # Purpose: validate both source tests and generated/installable artifacts.
 name: Verify
 
-"on":
+on:
   # Run on PRs targeting main so merge decisions are based on full verification.
   pull_request:
     branches: [main]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
-## [Unreleased] — 1.0.4
+## 1.0.5 — 2026-04-19
+
+Workflow hardening and release-manifest refresh.
+
+### Fixed in 1.0.5
+
+- GitHub Actions workflows now declare explicit `permissions` to satisfy policy checks and follow least-privilege defaults.
+
+### Changed in 1.0.5
+
+- `release.yml` now defaults to read-only workflow permissions and scopes `contents: write` to the `version-and-release` job only.
+- `qa.yml`, `security.yml`, and `verify.yml` now declare explicit workflow-level `permissions`.
+- `verify.yml` normalized to use `on:` (unquoted) for style consistency with other workflows.
+- `.github/vstack.json` refreshed via install to record the latest generated artifact manifest metadata.
+
+## 1.0.4 — 2026-04-19
 
 Skill expansion and documentation alignment update.
 
@@ -26,8 +41,6 @@ Skill expansion and documentation alignment update.
 - `README.md` role–skill table updated to reflect new primary skills per role.
 - `README.md` project structure diagram updated to include `instructions/` and `prompts/` template directories and the correct `docs/` subdirectory layout.
 - `.github/copilot-instructions.md` updated: system structure diagram now includes all four template artifact types (`skills`, `agents`, `instructions`, `prompts`); hand-authored `.github/` exceptions listed explicitly; install table extended with `instructions` and `prompts` rows.
-- GitHub Actions workflows now declare explicit `permissions` with least-privilege defaults; release write access is scoped to the release job only.
-- `verify.yml` normalized to use `on:` (unquoted) for style consistency with other workflows.
 
 ## 1.0.3 — 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Skill expansion and documentation alignment update.
 - `README.md` role–skill table updated to reflect new primary skills per role.
 - `README.md` project structure diagram updated to include `instructions/` and `prompts/` template directories and the correct `docs/` subdirectory layout.
 - `.github/copilot-instructions.md` updated: system structure diagram now includes all four template artifact types (`skills`, `agents`, `instructions`, `prompts`); hand-authored `.github/` exceptions listed explicitly; install table extended with `instructions` and `prompts` rows.
+- GitHub Actions workflows now declare explicit `permissions` with least-privilege defaults; release write access is scoped to the release job only.
+- `verify.yml` normalized to use `on:` (unquoted) for style consistency with other workflows.
 
 ## 1.0.3 — 2026-04-19
 


### PR DESCRIPTION
## Summary

This PR prepares the 1.0.5 release line with workflow hardening and manifest refresh.

What changed:
- Added explicit GitHub Actions permissions across workflows to satisfy policy checks and enforce least privilege.
- Updated release workflow permissions to default read-only, with write access scoped only to the version-and-release job.
- Normalized verify workflow syntax to use on: style consistent with the other workflows.
- Refreshed the generated vstack install manifest metadata.
- Updated changelog entries so 1.0.4 remains the released set and the latest branch changes are tracked as 1.0.5.

Why:
- Ensure workflow security policy compliance.
- Reduce token permission scope in CI/CD.
- Keep generated metadata and release documentation aligned.

## Related Issues

- No linked issue.
- Follow-up from workflow policy warning: Workflow does not contain permissions.

## Validation

- [ ] Tests pass locally
- [ ] CI checks pass
- [x] Docs updated (if needed)

## Release Impact

- [ ] feat: (minor)
- [x] fix: (patch)
- [ ] BREAKING CHANGE (major)
- [ ] No release impact