### PR TITLE
chore(dx): improve onboarding flow and feedback templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/first-run-report.md
+++ b/.github/DISCUSSION_TEMPLATE/first-run-report.md
@@ -1,0 +1,35 @@
+---
+title: "[First Run Report] "
+labels:
+  - onboarding
+  - first-run
+---
+
+## Outcome
+
+- Status: success / partial / blocked
+- Repository-scoped install used: yes/no
+
+## Commands you ran
+
+Paste the exact commands in order.
+
+## Expected vs actual
+
+- Expected:
+- Actual:
+
+## Errors (if any)
+
+Paste relevant error output snippets.
+
+## Environment details
+
+- OS:
+- Python version:
+- vstack version:
+- Copilot mode used: Agent / Ask / Edit
+
+## Follow-up
+
+What would have made this first run easier?

--- a/.github/DISCUSSION_TEMPLATE/model-cost-feedback.md
+++ b/.github/DISCUSSION_TEMPLATE/model-cost-feedback.md
@@ -1,0 +1,27 @@
+---
+title: "[Model and Cost Feedback] "
+labels:
+  - models
+  - cost
+  - feedback
+---
+
+## Role and task
+
+Which role/task were you running (for example `@architect`, `/verify`, `/security`)?
+
+## Model used
+
+Which model did you use?
+
+## Quality and speed
+
+How would you rate output quality and response speed?
+
+## Cost-value tradeoff
+
+Did the selected model feel cost-effective for this task?
+
+## Preferred default
+
+Which default model would you prefer for this role/task and why?

--- a/.github/DISCUSSION_TEMPLATE/onboarding-feedback.md
+++ b/.github/DISCUSSION_TEMPLATE/onboarding-feedback.md
@@ -1,0 +1,28 @@
+---
+title: "[Onboarding Feedback] "
+labels:
+  - onboarding
+  - feedback
+---
+
+## Context
+
+- First time using vstack: yes/no
+- Setup mode used: project (`--target`) / global (`--global`)
+- Environment: OS, Python version, editor version
+
+## What worked well
+
+Describe the parts of onboarding that felt clear and fast.
+
+## Where you got stuck
+
+List the exact step(s), commands, or docs that were unclear.
+
+## Time to first successful result
+
+How long did it take to run your first successful `@tester /verify` flow?
+
+## Suggested improvements
+
+If you could improve one thing for first-time users, what would it be?

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -120,4 +120,4 @@ Handoffs you own:
 - `@#analyse` — impact analysis, tradeoffs, feasibility
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"architect","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"architect","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -18,9 +18,9 @@ tools:
 agents:
   - *
 model:
-  - Claude Opus 4.6 (copilot)
   - Claude Sonnet 4.6 (copilot)
   - GPT-5.3-Codex (copilot)
+  - Claude Opus 4.7 (copilot)
 user-invocable: true
 target: vscode
 handoffs:
@@ -120,4 +120,4 @@ Handoffs you own:
 - `@#analyse` — impact analysis, tradeoffs, feasibility
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"architect","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"architect","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/agents/designer.agent.md
+++ b/.github/agents/designer.agent.md
@@ -131,4 +131,4 @@ Handoffs you own:
 - `@#openapi` — OpenAPI 3.1 spec writing and review
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"designer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"designer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/agents/designer.agent.md
+++ b/.github/agents/designer.agent.md
@@ -131,4 +131,4 @@ Handoffs you own:
 - `@#openapi` — OpenAPI 3.1 spec writing and review
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"designer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"designer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/agents/engineer.agent.md
+++ b/.github/agents/engineer.agent.md
@@ -121,4 +121,4 @@ Only delegate when workstreams are genuinely independent.
 - `@#incident` — incident analysis and post-mortem writing
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"engineer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"engineer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/agents/engineer.agent.md
+++ b/.github/agents/engineer.agent.md
@@ -121,4 +121,4 @@ Only delegate when workstreams are genuinely independent.
 - `@#incident` — incident analysis and post-mortem writing
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"engineer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"engineer","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/agents/product.agent.md
+++ b/.github/agents/product.agent.md
@@ -18,8 +18,8 @@ agents:
   - *
 model:
   - Claude Sonnet 4.6 (copilot)
-  - Claude Opus 4.6 (copilot)
   - GPT-5.3-Codex (copilot)
+  - Claude Opus 4.7 (copilot)
 user-invocable: true
 target: vscode
 handoffs:
@@ -122,4 +122,4 @@ Handoffs you own:
 - `@#onboard` — contributor onboarding guide generation
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"product","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"product","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/agents/product.agent.md
+++ b/.github/agents/product.agent.md
@@ -122,4 +122,4 @@ Handoffs you own:
 - `@#onboard` — contributor onboarding guide generation
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"product","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"product","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -118,4 +118,4 @@ Handoffs you own:
 - `@#code-review` — final review before PR is opened
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"release","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"release","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -118,4 +118,4 @@ Handoffs you own:
 - `@#code-review` — final review before PR is opened
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"release","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"release","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -126,4 +126,4 @@ Handoffs you own:
 - `@#incident` — incident analysis and post-mortem writing
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"tester","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"tester","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -126,4 +126,4 @@ Handoffs you own:
 - `@#incident` — incident analysis and post-mortem writing
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"tester","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"tester","artifact_type":"agent","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/instructions/git.instructions.md
+++ b/.github/instructions/git.instructions.md
@@ -41,4 +41,4 @@ Use these Git and release hygiene conventions in this project.
 1. Prefer local verification before pushing release-impacting changes.
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"git","artifact_type":"instruction","artifact_version":"0.1.0","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"git","artifact_type":"instruction","artifact_version":"0.1.0","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/instructions/git.instructions.md
+++ b/.github/instructions/git.instructions.md
@@ -41,4 +41,4 @@ Use these Git and release hygiene conventions in this project.
 1. Prefer local verification before pushing release-impacting changes.
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"git","artifact_type":"instruction","artifact_version":"0.1.0","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"git","artifact_type":"instruction","artifact_version":"0.1.0","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -42,4 +42,4 @@ Use these Python conventions in this project.
 1. Do not silence lint/type errors unless there is a documented, task-specific reason.
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"python","artifact_type":"instruction","artifact_version":"0.1.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"python","artifact_type":"instruction","artifact_version":"0.1.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -42,4 +42,4 @@ Use these Python conventions in this project.
 1. Do not silence lint/type errors unless there is a documented, task-specific reason.
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"python","artifact_type":"instruction","artifact_version":"0.1.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"python","artifact_type":"instruction","artifact_version":"0.1.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/prompts/code-review.prompt.md
+++ b/.github/prompts/code-review.prompt.md
@@ -50,4 +50,4 @@ End with:
 - Biggest remaining risk: one sentence
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"prompt","artifact_version":"0.1.0","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"prompt","artifact_version":"0.1.0","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/prompts/code-review.prompt.md
+++ b/.github/prompts/code-review.prompt.md
@@ -50,4 +50,4 @@ End with:
 - Biggest remaining risk: one sentence
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"prompt","artifact_version":"0.1.0","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"prompt","artifact_version":"0.1.0","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/adr/SKILL.md
+++ b/.github/skills/adr/SKILL.md
@@ -199,4 +199,4 @@ After writing, state the file path and summary so the architect or product role 
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"adr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"adr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/adr/SKILL.md
+++ b/.github/skills/adr/SKILL.md
@@ -199,4 +199,4 @@ After writing, state the file path and summary so the architect or product role 
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"adr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"adr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/analyse/SKILL.md
+++ b/.github/skills/analyse/SKILL.md
@@ -227,4 +227,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"analyse","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"analyse","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/analyse/SKILL.md
+++ b/.github/skills/analyse/SKILL.md
@@ -227,4 +227,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"analyse","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"analyse","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/architecture/SKILL.md
+++ b/.github/skills/architecture/SKILL.md
@@ -280,4 +280,4 @@ For each significant structural decision made during this review (technology cho
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"architecture","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"architecture","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/architecture/SKILL.md
+++ b/.github/skills/architecture/SKILL.md
@@ -280,4 +280,4 @@ For each significant structural decision made during this review (technology cho
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"architecture","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"architecture","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/cicd/SKILL.md
+++ b/.github/skills/cicd/SKILL.md
@@ -201,4 +201,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"cicd","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"cicd","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/cicd/SKILL.md
+++ b/.github/skills/cicd/SKILL.md
@@ -201,4 +201,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"cicd","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"cicd","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -219,4 +219,4 @@ Confidence: [HIGH/MEDIUM/LOW — explain if not HIGH]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -219,4 +219,4 @@ Confidence: [HIGH/MEDIUM/LOW — explain if not HIGH]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"code-review","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/concise/SKILL.md
+++ b/.github/skills/concise/SKILL.md
@@ -160,4 +160,4 @@ ______________________________________________________________________
 - [ ] User confirmation/status returned in deterministic format
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"concise","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"concise","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/concise/SKILL.md
+++ b/.github/skills/concise/SKILL.md
@@ -160,4 +160,4 @@ ______________________________________________________________________
 - [ ] User confirmation/status returned in deterministic format
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"concise","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"concise","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/consult/SKILL.md
+++ b/.github/skills/consult/SKILL.md
@@ -227,4 +227,4 @@ reason: [one sentence]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"consult","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"consult","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/consult/SKILL.md
+++ b/.github/skills/consult/SKILL.md
@@ -227,4 +227,4 @@ reason: [one sentence]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"consult","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"consult","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/container/SKILL.md
+++ b/.github/skills/container/SKILL.md
@@ -154,4 +154,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"container","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"container","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/container/SKILL.md
+++ b/.github/skills/container/SKILL.md
@@ -154,4 +154,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"container","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"container","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/debug/SKILL.md
+++ b/.github/skills/debug/SKILL.md
@@ -279,4 +279,4 @@ Prevention: [any follow-up items]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"debug","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"debug","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/debug/SKILL.md
+++ b/.github/skills/debug/SKILL.md
@@ -279,4 +279,4 @@ Prevention: [any follow-up items]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"debug","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"debug","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/dependency/SKILL.md
+++ b/.github/skills/dependency/SKILL.md
@@ -325,4 +325,4 @@ Action items (priority order):
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"dependency","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"dependency","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/dependency/SKILL.md
+++ b/.github/skills/dependency/SKILL.md
@@ -325,4 +325,4 @@ Action items (priority order):
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"dependency","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"dependency","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/design/SKILL.md
+++ b/.github/skills/design/SKILL.md
@@ -263,4 +263,4 @@ Output a complete design document to `docs/design/design.md` or `openapi.yaml`:
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"design","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"design","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/design/SKILL.md
+++ b/.github/skills/design/SKILL.md
@@ -263,4 +263,4 @@ Output a complete design document to `docs/design/design.md` or `openapi.yaml`:
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"design","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"design","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/docs/SKILL.md
+++ b/.github/skills/docs/SKILL.md
@@ -167,4 +167,4 @@ Skipped (n/a):
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"docs","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"docs","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/docs/SKILL.md
+++ b/.github/skills/docs/SKILL.md
@@ -167,4 +167,4 @@ Skipped (n/a):
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"docs","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"docs","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/explore/SKILL.md
+++ b/.github/skills/explore/SKILL.md
@@ -241,4 +241,4 @@ Stack:   [language, framework, runtime versions]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"explore","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"explore","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/explore/SKILL.md
+++ b/.github/skills/explore/SKILL.md
@@ -241,4 +241,4 @@ Stack:   [language, framework, runtime versions]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"explore","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"explore","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/guardrails/SKILL.md
+++ b/.github/skills/guardrails/SKILL.md
@@ -77,4 +77,4 @@ Explicitly ask to "disable guardrails".
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"guardrails","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"guardrails","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/guardrails/SKILL.md
+++ b/.github/skills/guardrails/SKILL.md
@@ -77,4 +77,4 @@ Explicitly ask to "disable guardrails".
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"guardrails","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"guardrails","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/incident/SKILL.md
+++ b/.github/skills/incident/SKILL.md
@@ -325,4 +325,4 @@ Status:               [Draft — ready for team review]
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"incident","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"incident","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/incident/SKILL.md
+++ b/.github/skills/incident/SKILL.md
@@ -325,4 +325,4 @@ Status:               [Draft — ready for team review]
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"incident","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"incident","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/inspect/SKILL.md
+++ b/.github/skills/inspect/SKILL.md
@@ -165,4 +165,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"inspect","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"inspect","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/inspect/SKILL.md
+++ b/.github/skills/inspect/SKILL.md
@@ -165,4 +165,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"inspect","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"inspect","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/migrate/SKILL.md
+++ b/.github/skills/migrate/SKILL.md
@@ -337,4 +337,4 @@ Pre-deploy checklist:
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"migrate","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"migrate","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/migrate/SKILL.md
+++ b/.github/skills/migrate/SKILL.md
@@ -337,4 +337,4 @@ Pre-deploy checklist:
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"migrate","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"migrate","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/onboard/SKILL.md
+++ b/.github/skills/onboard/SKILL.md
@@ -321,4 +321,4 @@ Gaps remaining (if any):
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"onboard","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"onboard","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/onboard/SKILL.md
+++ b/.github/skills/onboard/SKILL.md
@@ -321,4 +321,4 @@ Gaps remaining (if any):
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"onboard","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"onboard","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/openapi/SKILL.md
+++ b/.github/skills/openapi/SKILL.md
@@ -414,4 +414,4 @@ Summary: [N critical, N warnings, N info]
 `$ref` for all reusable schemas, and validate it passes linting.
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"openapi","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"openapi","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/openapi/SKILL.md
+++ b/.github/skills/openapi/SKILL.md
@@ -414,4 +414,4 @@ Summary: [N critical, N warnings, N info]
 `$ref` for all reusable schemas, and validate it passes linting.
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"openapi","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"openapi","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/performance/SKILL.md
+++ b/.github/skills/performance/SKILL.md
@@ -258,4 +258,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"performance","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"performance","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/performance/SKILL.md
+++ b/.github/skills/performance/SKILL.md
@@ -258,4 +258,4 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"performance","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"performance","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/pr/SKILL.md
+++ b/.github/skills/pr/SKILL.md
@@ -140,4 +140,4 @@ CI/CD will now:
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"pr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"pr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/pr/SKILL.md
+++ b/.github/skills/pr/SKILL.md
@@ -140,4 +140,4 @@ CI/CD will now:
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"pr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"pr","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/refactor/SKILL.md
+++ b/.github/skills/refactor/SKILL.md
@@ -385,4 +385,4 @@ Behavior changed:   No
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"refactor","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"refactor","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/refactor/SKILL.md
+++ b/.github/skills/refactor/SKILL.md
@@ -385,4 +385,4 @@ Behavior changed:   No
 ```
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"refactor","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"refactor","artifact_type":"skill","artifact_version":"1.0.1","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -159,4 +159,4 @@ Keep existing entries intact.
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"release-notes","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"release-notes","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -159,4 +159,4 @@ Keep existing entries intact.
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"release-notes","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"release-notes","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/requirements/SKILL.md
+++ b/.github/skills/requirements/SKILL.md
@@ -219,4 +219,4 @@ After writing, summarize what was decided so the architect role can start.
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"requirements","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"requirements","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/requirements/SKILL.md
+++ b/.github/skills/requirements/SKILL.md
@@ -219,4 +219,4 @@ After writing, summarize what was decided so the architect role can start.
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"requirements","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"requirements","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/security/SKILL.md
+++ b/.github/skills/security/SKILL.md
@@ -295,4 +295,4 @@ Scope: [full/diff/dependency/config]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"security","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"security","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/security/SKILL.md
+++ b/.github/skills/security/SKILL.md
@@ -295,4 +295,4 @@ Scope: [full/diff/dependency/config]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"security","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"security","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/verify/SKILL.md
+++ b/.github/skills/verify/SKILL.md
@@ -282,4 +282,4 @@ scope: [path/component/full]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"verify","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"verify","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/verify/SKILL.md
+++ b/.github/skills/verify/SKILL.md
@@ -282,4 +282,4 @@ scope: [path/component/full]
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"verify","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"verify","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/skills/vision/SKILL.md
+++ b/.github/skills/vision/SKILL.md
@@ -208,4 +208,4 @@ Present as: "Overall assessment: [READY/NEEDS REVISION/SCOPE CHANGE] because [1-
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"vision","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"0.0.0.post3.dev0+df3fe6e"} -->
+<!-- VSTACK-META: {"artifact_name":"vision","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->

--- a/.github/skills/vision/SKILL.md
+++ b/.github/skills/vision/SKILL.md
@@ -208,4 +208,4 @@ Present as: "Overall assessment: [READY/NEEDS REVISION/SCOPE CHANGE] because [1-
 ______________________________________________________________________
 
 <!-- AUTO-GENERATED — maintained by vstack, do not edit directly -->
-<!-- VSTACK-META: {"artifact_name":"vision","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.2.5"} -->
+<!-- VSTACK-META: {"artifact_name":"vision","artifact_type":"skill","artifact_version":"1.0.2","generator":"vstack","vstack_version":"1.3.0"} -->

--- a/.github/vstack.json
+++ b/.github/vstack.json
@@ -1,6 +1,6 @@
 {
-  "vstack_version": "1.2.5",
-  "installed_at": "2026-04-21T21:51:23.985830+00:00",
+  "vstack_version": "1.3.0",
+  "installed_at": "2026-04-21T22:51:50.907279+00:00",
   "artifacts": {
     "skills": [
       {

--- a/.github/vstack.json
+++ b/.github/vstack.json
@@ -1,6 +1,6 @@
 {
-  "vstack_version": "0.0.0.post3.dev0+df3fe6e",
-  "installed_at": "2026-04-20T22:37:59.699083+00:00",
+  "vstack_version": "1.2.5",
+  "installed_at": "2026-04-21T21:51:23.985830+00:00",
   "artifacts": {
     "skills": [
       {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  version-and-release:
+  release:
     # Computes semantic version from conventional commits, creates git tag,
     # and publishes GitHub release.
     name: Compute Version and Tag
@@ -120,17 +120,19 @@ jobs:
           name: Release v${{ steps.version.outputs.version }} (${{ steps.release_date.outputs.date }})
           generate_release_notes: true
 
-  build-artifacts:
+  build:
     # Build distributions only when semver-action reports a new release.
     name: Build Package Artifacts
     runs-on: ubuntu-latest
-    needs: version-and-release
-    if: github.event.pull_request.merged == true && needs.version-and-release.outputs.changed == 'true'
+    needs: release
+    if: github.event.pull_request.merged == true && needs.release.outputs.changed == 'true'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          # Full history and tags required by poetry-dynamic-versioning.
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Install Poetry
@@ -151,3 +153,24 @@ jobs:
         with:
           name: python-dist
           path: dist/
+
+  publish:
+    # Publish distributions to PyPI via OIDC trusted publishing (no API tokens).
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [release, build]
+    if: github.event.pull_request.merged == true && needs.release.outputs.changed == 'true'
+    environment: pypi
+    permissions:
+      # Required for OIDC trusted publishing.
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 1.2.6 - 2026-04-22
+## 1.3.0 - 2026-04-22
 
-DX and onboarding quality release.
+DX, onboarding, and PyPI publishing release.
 
-### Added in 1.2.6
+### Added in 1.3.0
 
 - Added GitHub Discussion templates for onboarding and adoption feedback:
   - `onboarding-feedback`
@@ -14,11 +14,12 @@ DX and onboarding quality release.
 - Added explicit expected output examples for first install validation in `README.md`.
 - Added a troubleshooting decision flowchart in `README.md`.
 
-### Changed in 1.2.6
+### Changed in 1.3.0
 
 - Restructured `README.md` for faster onboarding with clearer quick paths, role usage guidance, and troubleshooting navigation.
 - Updated architect and product agent template model ordering and regenerated installed agent artifacts.
 - Updated generated artifact metadata and aligned generation tests with current template output.
+- Added PyPI publish job to release workflow using OIDC trusted publishing (no API tokens required).
 
 ## 1.2.5 - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 1.2.6 - 2026-04-22
+
+DX and onboarding quality release.
+
+### Added in 1.2.6
+
+- Added GitHub Discussion templates for onboarding and adoption feedback:
+  - `onboarding-feedback`
+  - `first-run-report`
+  - `model-cost-feedback`
+- Added team setup guidance in `README.md` with project-first install flow and expected outcomes.
+- Added explicit expected output examples for first install validation in `README.md`.
+- Added a troubleshooting decision flowchart in `README.md`.
+
+### Changed in 1.2.6
+
+- Restructured `README.md` for faster onboarding with clearer quick paths, role usage guidance, and troubleshooting navigation.
+- Updated architect and product agent template model ordering and regenerated installed agent artifacts.
+- Updated generated artifact metadata and aligned generation tests with current template output.
+
+## 1.2.5 - 2026-04-21
+
+CI dependency maintenance release.
+
+### Changed in 1.2.5
+
+- GitHub Actions: bumped `actions/checkout` from v5 to v6.
+
+## 1.2.4 - 2026-04-21
+
+CI dependency maintenance release.
+
+### Changed in 1.2.4
+
+- GitHub Actions: bumped `actions/upload-artifact` from v4 to v7.
+
+## 1.2.3 - 2026-04-21
+
+Release workflow dependency maintenance.
+
+### Changed in 1.2.3
+
+- GitHub Actions: bumped `softprops/action-gh-release` from v2 to v3.
+
+## 1.2.2 - 2026-04-21
+
+Security workflow dependency maintenance.
+
+### Changed in 1.2.2
+
+- GitHub Actions: bumped `trufflesecurity/trufflehog` from `3.88.2` to `3.94.3`.
+
 ## 1.2.1 - 2026-04-21
 
 README rendering fix release.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
     <img src="assets/branding/vstack.png" alt="vstack" width="400">
   </picture>
 
-[![Python](https://img.shields.io/badge/python-3.11--3.14-0B8A6F)](pyproject.toml)
-[![Verify](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/verify.yml?branch=main&label=verify&color=1D6FA5)](https://github.com/eschaar/vstack/actions/workflows/verify.yml)
-[![Security](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/security.yml?branch=main&label=security&color=B15E00)](https://github.com/eschaar/vstack/actions/workflows/security.yml)
-[![Runtime](https://img.shields.io/badge/runtime-stdlib%20only-5B6C8F)](pyproject.toml)
-[![License](https://img.shields.io/github/license/eschaar/vstack?color=5F7A1F)](LICENSE)
+[![Python version](https://img.shields.io/badge/python-3.11--3.14-0B8A6F "Supported Python versions")](pyproject.toml)
+[![Verify status](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/verify.yml?branch=main&label=verify&color=1D6FA5 "Build and test status")](https://github.com/eschaar/vstack/actions/workflows/verify.yml)
+[![Security checks](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/security.yml?branch=main&label=security&color=B15E00 "Security workflow status")](https://github.com/eschaar/vstack/actions/workflows/security.yml)
+[![Runtime: stdlib only](https://img.shields.io/badge/runtime-stdlib%20only-5B6C8F "No runtime dependencies")](pyproject.toml)
+[![License: MIT](https://img.shields.io/github/license/eschaar/vstack?color=5F7A1F "Project license")](LICENSE)
+[![GitHub Discussions](https://img.shields.io/badge/discussions-ask%20%26%20share-blueviolet?logo=github "GitHub Discussions")](https://github.com/eschaar/vstack/discussions)
 
 </div>
+
+> **The VS Code-native AI workflow system for backend engineering.**
 
 vstack is a VS Code-native AI engineering workflow system for backend services,
 libraries, APIs, and adjacent platform work. It installs structured agents,
@@ -26,7 +29,7 @@ but was rebuilt around a template-driven, VS Code-first workflow model.
 
 ______________________________________________________________________
 
-## Why vstack
+## ❔ Why vstack
 
 - Fixed role model with explicit ownership boundaries
 - Template-driven install model from `src/vstack/_templates/`
@@ -36,65 +39,440 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## Quickstart
+## 🧭 Quick navigation
 
-Requires **Python 3.11-3.14**.
+For new users:
 
-### Distribution status
+- Quickstart
+- Quick check
+- Using vstack in Copilot Agent Mode
+- Try it now
+- Troubleshooting
 
-vstack is not published to PyPI yet. The current workflow is source-based usage
-from this repository.
+For experienced users:
 
-### 1. Clone and install the development environment
+- Role summary
+- Example usage
+- All vstack CLI commands
+- Workflow
+- Development
+- CI and Release Automation
+
+### ⚡ Quick paths
+
+#### New user path (2 minutes)
+
+```bash
+pipx install git+https://github.com/eschaar/vstack.git
+vstack install --target /path/to/your/project
+vstack validate
+```
+
+Then in Copilot Agent Mode:
+
+```text
+@tester /verify Check this repository and summarize findings
+```
+
+#### Power user path (30 seconds)
+
+```bash
+vstack install --target /path/to/your/project && vstack verify --target /path/to/your/project
+```
+
+Then jump straight into your role workflow:
+
+```text
+@architect Review contracts in src/api/
+@engineer /code-review
+@tester /security
+```
+
+```mermaid
+flowchart LR
+  A[Install CLI] --> B[Install artifacts per repo]
+  B --> C[Validate setup]
+  C --> D[Run @tester /verify]
+  D --> E[Role-based flow]
+```
+
+______________________________________________________________________
+
+## 🚀 Quickstart
+
+> New here? Start with `pipx install ...`, then run `vstack install --target ...`, then try `@tester /verify` in Copilot Agent Mode.
+
+### ⚡ Install with pipx (recommended)
+
+You can install and use vstack directly without cloning:
+
+```bash
+pipx install git+https://github.com/eschaar/vstack.git
+```
+
+Afterwards, the `vstack` command is available everywhere:
+
+```bash
+# Recommended: install vstack artifacts per project/repository
+vstack install --target /path/to/your/project
+
+# Optional: install profile-wide defaults for all VS Code projects
+vstack install --global
+```
+
+### 🐙 Alternative: manual clone and install
 
 ```bash
 git clone git@github.com:eschaar/vstack.git
 cd vstack
 poetry install
-```
-
-### 2. Install the artifacts
-
-From the checked-out repository, install artifacts into one repository:
-
-```bash
 poetry run vstack install --target /path/to/your/project
 ```
 
-Or install into your VS Code profile so the artifacts are available across projects:
+### 🤝 Team setup (recommended for teams)
+
+Use repository-scoped installation so every contributor and CI run uses the same agent setup.
+
+1. Install artifacts into the repository.
+1. Commit the generated `.github/` artifacts.
+1. Require `verify.yml` and `security.yml` checks before merge.
 
 ```bash
-poetry run vstack install --global
+# From your repository root
+vstack install --target /path/to/your/project
+git add .github
+git commit -m "chore: install vstack artifacts"
 ```
 
-If you prefer, you can also run the package entrypoint after an editable install in
-your active environment.
+Expected outcome:
 
-### 3. Open Copilot Agent Mode and invoke a role
+- Teammates get the same agents and skills after `git pull`.
+- CI validates the same repository-level setup.
+
+## 🚦 Quick check: Is vstack working?
+
+After install, run:
+
+```bash
+vstack --version
+vstack validate
+```
+
+If you see the version and no errors, your install is working.
+
+Expected output (example):
 
 ```text
-@product Review my plan for a payments service
-@architect Review the API contracts in src/api/
-@tester /security Audit the authentication module
+vstack 1.2.5
+Validation passed: no unresolved template tokens
 ```
 
-No extra VS Code settings are required. Installed role agents are discovered from
-workspace `.github/agents/` and from the VS Code user profile.
+### First use example
+
+Open Copilot Agent Mode and run:
+
+```text
+@tester /verify Check this repository and summarize findings
+```
+
+You should receive a concise verification summary for your current workspace.
+
+### 💬 Using vstack in Copilot Agent Mode
+
+For new users (first 5 minutes):
+
+- Follow the 3-step flow below exactly once.
+- Start with `@tester /verify` to confirm the setup works.
+
+For experienced users:
+
+- Use direct role invocation (`@product`, `@architect`, `@engineer`, etc.) for context-rich execution.
+- Use direct skills (`/verify`, `/security`, `/code-review`) for focused, faster runs.
+
+1. **Open Copilot Chat**
+   - Use `Ctrl+Shift+I` (Windows/Linux) or `Cmd+Shift+I` (Mac), or click the Copilot icon in the sidebar.
+1. **Switch to Agent Mode**
+   - In the Copilot Chat panel, change the mode selector from `Ask` to `Agent`.
+1. **Invoke a role agent**
+   - Type e.g.:
+     ```text
+     @product Review my plan for a payments service
+     @architect Review the API contracts in src/api/
+     @tester /security Audit the authentication module
+     ```
+   - The `@role` prefix selects the corresponding agent. You can add a skill command (e.g. `/security`) after the agent for a focused procedure.
+
+**How it works:**
+
+- When you use `@role` (e.g. `@tester`), the agent loads all relevant skills and instructions for that role. Skills are discovered automatically and routed by the agent based on your request.
+- If you use only a skill (e.g. `/verify`), a prompt, or an instruction (without an explicit agent), VS Code Copilot Agent Mode will use the default agent for the context (typically `@tester` for verification-related skills, or the most relevant role based on your workspace and prompt). This means you can use `/verify`, `/security`, or other skills directly, and they will work even without specifying an agent.
+- Agents are not invoked automatically; you must use the `@role` prefix to select a specific agent and role context. Skills, prompts, and instructions are always auto-discovered and available in the background.
+- For maximum control and clarity, always specify the agent (`@role`) when you want a particular role's framing, default behavior, or skill routing.
 
 ______________________________________________________________________
 
-## Flow
+#### 🧩 Visual: How agents, skills, instructions, and prompts interact
+
+```mermaid
+flowchart TD
+  subgraph "VS Code Copilot Agent Mode"
+    A["User prompt"]
+    B["Agent (e.g. @tester)"]
+    C["Skills (e.g. /verify, /security)"]
+    D["Instructions"]
+    E["Prompts"]
+  end
+  A --> B
+  B --> C
+  B --> D
+  B --> E
+  C -.-> B
+  E -.-> B
+  D -.-> B
+```
+
+**Legend:**
+
+- **Agents** (`@role`): Main entrypoint, routes and coordinates work.
+- **Skills** (`/skill`): Reusable procedures, invoked by agents or directly.
+- **Instructions**: Baseline policies, always loaded by agents.
+- **Prompts**: Reusable prompt artifacts, used as needed.
+
+______________________________________________________________________
+
+## 🧪 Try it now
+
+Open Copilot Agent Mode and enter:
+
+```text
+@tester /verify Check this repo
+```
+
+You should see a verification summary for your current project.
+
+______________________________________________________________________
+
+## 🧑‍💻 Role summary
+
+| Role      | Emoji | Invocation   | Primary areas                                           | Example invocation                    |
+| --------- | ----- | ------------ | ------------------------------------------------------- | ------------------------------------- |
+| Product   | 🧑‍💼    | `@product`   | Vision, requirements, onboarding, docs                  | `@product Review my plan`             |
+| Architect | 🏗️    | `@architect` | Architecture, ADRs                                      | `@architect Review the API contracts` |
+| Designer  | 🎨    | `@designer`  | Service design, OpenAPI, DX review                      | `@designer Review the OpenAPI spec`   |
+| Engineer  | 🛠️    | `@engineer`  | Implementation, debugging, refactoring, dependency work | `@engineer /code-review`              |
+| Tester    | 🧪    | `@tester`    | Verification, security, incident review, performance    | `@tester /verify`                     |
+| Release   | 🚀    | `@release`   | Release notes, PR creation, release gating              | `@release Prepare release notes`      |
+
+### Role-to-skill mapping
+
+| Role      | Invocation   | Primary skills                                          | Default concise mode |
+| --------- | ------------ | ------------------------------------------------------- | -------------------- |
+| product   | `@product`   | vision, requirements, onboard, docs                     | compact              |
+| architect | `@architect` | architecture, adr                                       | normal               |
+| designer  | `@designer`  | design, openapi, consult, docs                          | compact              |
+| engineer  | `@engineer`  | code-review, debug, refactor, migrate, dependency, docs | compact              |
+| tester    | `@tester`    | verify, inspect, security, incident, dependency, docs   | ultra                |
+| release   | `@release`   | release-notes, pr, docs                                 | compact              |
+
+______________________________________________________________________
+
+> ℹ️ **Tip:** Use the `@role` prefix for full context and best results. Skills like `/verify` also work directly, but explicit roles give you more control.
+
+______________________________________________________________________
+
+> 💡 **Pro tip:** Try combining agents and skills for focused tasks, e.g. `@tester /security` or `@engineer /code-review`.
+
+______________________________________________________________________
+
+## 📝 Example usage
+
+### Idea to release
+
+1. `@product` to lock requirements and success criteria.
+1. `@architect` to define service boundaries and ADRs.
+1. `@designer` to define APIs, schemas, and flows.
+1. `@engineer` to implement.
+1. `@tester` to verify behavior and risk.
+1. `@release` to prepare release artifacts and PR flow.
+
+### Direct skill usage
+
+| Goal                | Agent invocation | Optional direct skill |
+| ------------------- | ---------------- | --------------------- |
+| Requirements        | `@product`       |                       |
+| Architecture review | `@architect`     |                       |
+| API design          | `@designer`      |                       |
+| Code review         | `@engineer`      | `/code-review`        |
+| Verification        | `@tester`        | `/verify`             |
+| Security audit      | `@tester`        | `/security`           |
+| Performance check   | `@tester`        | `/performance`        |
+
+### Subagent orchestration pattern
+
+```text
+@product Deliver a requirements-to-release plan for a new payments service
+```
+
+Typical downstream path: `@product` -> `@architect` -> `@designer` -> `@engineer` -> `@tester` -> `@release`.
+
+______________________________________________________________________
+
+## ❓ FAQ
+
+**Q: Why don't I see agents in Copilot?**
+A: In a specific repository, run `vstack install --target /path/to/your/project` (or run `vstack install` from the repo root), then reload VS Code. Use `--global` only when you want profile-wide defaults.
+
+**Q: Which Python version do I need?**
+A: Python 3.11–3.14 (see badges above).
+
+**Q: How do I reset the install?**
+A: For one repository, run `vstack uninstall --target /path/to/your/project` and then reinstall with `vstack install --target /path/to/your/project`. Use `--global` only for profile-wide defaults.
+
+**Q: Where can I ask questions or give feedback?**
+A: [Start a discussion or ask a question here.](https://github.com/eschaar/vstack/discussions)
+
+______________________________________________________________________
+
+## 🧹 Uninstall / Reset
+
+To remove vstack artifacts from your project or profile, use the CLI:
+
+```bash
+# Uninstall vstack artifacts from your current project
+vstack uninstall --target /path/to/your/project
+
+# Uninstall vstack artifacts from your global VS Code profile
+vstack uninstall --global
+```
+
+To remove vstack itself (the CLI):
+
+```bash
+# If installed with pipx
+pipx uninstall vstack
+
+# If installed with pip in an active environment
+pip uninstall vstack
+
+# If installed from a local clone for development
+rm -rf .venv
+```
+
+You can also manually remove any leftover `.github/agents`, `.github/skills`, etc. if needed.
+
+## ⚡ Essential CLI commands
+
+```bash
+vstack --version           # Show vstack version
+vstack validate            # Validate current vstack install
+vstack install --target .  # Install vstack artifacts into current project
+vstack install --global    # Install vstack artifacts globally
+vstack uninstall --target . # Uninstall vstack artifacts from current project
+vstack uninstall --global  # Uninstall vstack artifacts globally
+```
+
+______________________________________________________________________
+
+## 📖 All vstack CLI commands
+
+| Command                         | Description                                          |
+| ------------------------------- | ---------------------------------------------------- |
+| `vstack --version`              | Show vstack version                                  |
+| `vstack validate`               | Validate vstack install and check for issues         |
+| `vstack verify`                 | Verify source templates and/or installed output      |
+| `vstack verify --target DIR`    | Verify installed artifacts in DIR/.github            |
+| `vstack verify --global`        | Verify artifacts in your VS Code global profile      |
+| `vstack install --target DIR`   | Install vstack artifacts into a project              |
+| `vstack install --global`       | Install vstack artifacts into your VS Code profile   |
+| `vstack install --dry-run`      | Preview install actions without writing files        |
+| `vstack uninstall --target DIR` | Uninstall vstack artifacts from a project            |
+| `vstack uninstall --global`     | Uninstall vstack artifacts from your VS Code profile |
+| `vstack uninstall`              | Uninstall from the current directory default target  |
+
+______________________________________________________________________
+
+## 🤝 How to contribute
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, code style, and how to get started.
+
+______________________________________________________________________
+
+## 🛠️ Troubleshooting
+
+Quick index:
+[Installation and environment](#installation-and-environment) · [Copilot Agent Mode](#copilot-agent-mode) · [CI parity and badges](#ci-parity-and-badges) · [VS Code search noise](#vs-code-search-noise)
+
+```mermaid
+flowchart TD
+  A[Problem observed] --> B{Install or environment issue?}
+  B -->|Yes| C[Check pipx/poetry/python version]
+  B -->|No| D{Agents visible in Copilot?}
+  D -->|No| E[Run vstack install --target and reload VS Code]
+  D -->|Yes| F{CI mismatch or badge confusion?}
+  F -->|CI mismatch| G[Run make bootstrap then make check or make ci]
+  F -->|Badge no status| H[Verify PR-based workflow trigger]
+  F -->|Search noisy| I[Set search.exclude and files.watcherExclude]
+  C --> J[Resolved]
+  E --> J
+  G --> J
+  H --> J
+  I --> J
+```
+
+### Installation and environment
+
+- Issue: `pipx: command not found`
+  Action: Install pipx with `pip install --user pipx`.
+- Issue: `poetry: command not found`
+  Action: Follow the Poetry install guide at [https://python-poetry.org/docs/#installation](https://python-poetry.org/docs/#installation).
+- Issue: `Python version not supported`
+  Action: Use Python 3.11-3.14.
+- Issue: `Permission denied` during install or uninstall
+  Action: Check directory permissions and rerun with appropriate privileges.
+- Issue: `Could not detect VS Code user data directory`
+  Action: Run with an explicit target, for example `vstack install --target ~/.config/Code/User`.
+
+### Copilot Agent Mode
+
+- Issue: Agents do not appear in one repository
+  Action: Run `vstack install --target /path/to/your/project` (or run `vstack install` from that repository root), then reload VS Code.
+- Issue: Agents appear in one repository but not another
+  Action: Install per repository with `vstack install --target ...` in each repo, or use `vstack install --global` for profile-wide defaults.
+- Issue: Agents still do not appear
+  Action: Confirm templates exist under `src/vstack/_templates/agents/`, then run `Developer: Reload Window` in VS Code.
+- Issue: Agent does not execute actions
+  Action: Make sure Copilot is in Agent Mode, not Ask or Edit mode.
+
+### CI parity and badges
+
+- Issue: Checks pass in CI but fail locally
+  Action: Run `make bootstrap` once per clone, then run `make check`.
+- Issue: Need to mirror the CI quality gate locally
+  Action: Run `make ci`.
+- Issue: Verify or Security badge shows no status
+  Action: These workflows are PR-based, so main may not always show a latest status.
+
+### VS Code search noise
+
+- Issue: Search results are noisy
+  Action: Exclude `.venv`, `venv`, `env`, `node_modules`, `__pycache__`, `dist`, `build`, and `.git`.
+- Issue: Search still feels slow or cluttered
+  Action: Configure both `search.exclude` and `files.watcherExclude` in VS Code settings.
+
+______________________________________________________________________
+
+## 🔄 Workflow
 
 ```mermaid
 flowchart LR
-    A[Product intent] --> B["@product"]
-    B --> C["@architect"]
-    C --> D["@designer"]
-    D --> E["@engineer"]
-    E --> F["@tester"]
-    F --> G["@release"]
-    B -. focused procedure .-> H["requirements or vision"]
-    F -. focused procedure .-> I["verify, security, performance"]
+  A[Product intent] --> B["@product"]
+  B --> C["@architect"]
+  C --> D["@designer"]
+  D --> E["@engineer"]
+  E --> F["@tester"]
+  F --> G["@release"]
+  B -. focused procedure .-> H["requirements or vision"]
+  F -. focused procedure .-> I["verify, security, performance"]
 ```
 
 The exact deliverable can be a microservice, API, package, library, app, or broader
@@ -102,13 +480,13 @@ system. The product vision defines scope; vstack defines how the work is carried
 
 ______________________________________________________________________
 
-## Building Blocks
+## 🧱 Building Blocks
 
 | Artifact type | Purpose                                                    | Typical invocation     |
 | ------------- | ---------------------------------------------------------- | ---------------------- |
 | Agents        | Main operating interface for role-based work               | `@product`, `@tester`  |
 | Skills        | Reusable task procedures                                   | `/verify`, `/security` |
-| Instructions  | Baseline policy and repo guardrails                        | auto-loaded by context |
+| Instructions  | Baseline policy and repository guardrails                  | auto-loaded by context |
 | Prompts       | Reusable prompt artifacts where direct prompting is useful | explicit prompt use    |
 
 Boundary rule:
@@ -122,122 +500,32 @@ See [docs/design/instructions.md](docs/design/instructions.md),
 
 ______________________________________________________________________
 
-## Roles
+## 🧠 Model Guidance
 
-| Role      | Invocation   | Primary areas                                           |
-| --------- | ------------ | ------------------------------------------------------- |
-| product   | `@product`   | vision, requirements, onboarding, docs                  |
-| architect | `@architect` | architecture, ADRs                                      |
-| designer  | `@designer`  | service design, OpenAPI, DX review                      |
-| engineer  | `@engineer`  | implementation, debugging, refactoring, dependency work |
-| tester    | `@tester`    | verification, security, incident review, performance    |
-| release   | `@release`   | release notes, PR creation, release gating              |
+| Use case                 | Recommended model floor (or higher)                  |
+| ------------------------ | ---------------------------------------------------- |
+| `@product`, `@architect` | Claude Sonnet 4.6+, GPT-5.3-Codex+, Claude Opus 4.6+ |
+| `@tester`, `@engineer`   | Claude Sonnet 4.6+ or GPT-5.3-Codex+                 |
+| `@release`               | Claude Sonnet 4.6+                                   |
+| Complex debugging        | GPT-5.3-Codex+ or Claude Opus 4.6+                   |
+| Quick tasks              | Any model with tool and agent-mode support           |
 
-Full skill index: [docs/design/skills.md](docs/design/skills.md)
+Why these version floors:
 
-______________________________________________________________________
+- Reliable tool use and structured instruction following in Agent Mode.
+- Better multi-step planning and stronger handling of long procedural prompts.
+- Better compatibility with subagent-style orchestration and role handoffs.
+- More stable output quality for repository-scale reviews and verification loops.
 
-## Example Usage
+Practical cost guidance:
 
-### Idea to release
-
-1. `@product` to lock requirements and success criteria
-1. `@architect` to define service boundaries and ADRs
-1. `@designer` to define APIs, schemas, and flows
-1. `@engineer` to implement
-1. `@tester` to verify behavior and risk
-1. `@release` to prepare the release path
-
-### Direct skill usage when you want a focused tool
-
-| Goal                | Agent invocation | Optional direct skill |
-| ------------------- | ---------------- | --------------------- |
-| Requirements        | `@product`       |                       |
-| Architecture review | `@architect`     |                       |
-| API design          | `@designer`      |                       |
-| Code review         | `@engineer`      | `/code-review`        |
-| Verification        | `@tester`        | `/verify`             |
-| Security audit      | `@tester`        | `/security`           |
-| Performance check   | `@tester`        | `/performance`        |
-
-You can also force a skill through an agent when you want the role framing and the
-procedure together, for example `@tester /security`.
-
-### Subagent pattern
-
-The product agent can invoke other agents as subagents to orchestrate a complete flow:
-
-```text
-@product Deliver a requirements-to-release plan for a new payments service
-```
-
-Typical downstream path:
-
-- `@product` -> requirements
-- `@architect` -> architecture
-- `@designer` -> API contract
-- `@engineer` -> implementation
-- `@tester` -> verification
-- `@release` -> release gating
+- Use Claude Sonnet 4.6+ as the default for most runs (best speed/cost balance).
+- Use GPT-5.3-Codex+ for deep code reasoning, debugging, and implementation-heavy tasks.
+- Use Claude Opus 4.6+ selectively for high-ambiguity architecture tradeoffs where the extra cost is justified.
 
 ______________________________________________________________________
 
-## Using vstack in Copilot Agent Mode
-
-### 1. Open Copilot Chat
-
-Use `Ctrl+Shift+I` or `Cmd+Shift+I`, or click the Copilot icon in the sidebar.
-
-### 2. Switch to Agent Mode
-
-In the Copilot Chat panel, switch the mode selector from `Ask` to `Agent`.
-
-### 3. Invoke a role
-
-```text
-@product Review my plan for the new payments service
-@architect Review the API contracts in src/api/
-@tester
-@tester Run a security audit
-```
-
-Each role agent uses the appropriate skills automatically. You can also ask a role
-to use a specific skill:
-
-```text
-@tester use the verify skill with regression focus and report findings
-@tester run the security skill on the auth module
-```
-
-### 4. Available roles and their primary skills
-
-| Role      | Invocation   | Primary skills                                          | Default concise mode |
-| --------- | ------------ | ------------------------------------------------------- | -------------------- |
-| product   | `@product`   | vision, requirements, onboard, docs                     | compact              |
-| architect | `@architect` | architecture, adr                                       | normal               |
-| designer  | `@designer`  | design, openapi, consult, docs                          | compact              |
-| engineer  | `@engineer`  | code-review, debug, refactor, migrate, dependency, docs | compact              |
-| tester    | `@tester`    | verify, inspect, security, incident, dependency, docs   | ultra                |
-| release   | `@release`   | release-notes, pr, docs                                 | compact              |
-
-______________________________________________________________________
-
-## Model Guidance
-
-| Use case                 | Recommended model                    |
-| ------------------------ | ------------------------------------ |
-| `@product`, `@architect` | Claude Sonnet 4.6 or Claude Opus 4.6 |
-| `@tester`, `@engineer`   | Claude Sonnet 4.6                    |
-| `@release`               | Claude Sonnet 4.6                    |
-| Complex debugging        | Claude Opus 4.6 or GPT-5.3 Codex     |
-| Quick tasks              | Any model                            |
-
-Claude Sonnet 4.6 is the best balance of speed, quality, and cost for most runs.
-Use Claude Opus 4.6 for architecture reviews or complex debugging.
-
-______________________________________________________________________
-
-## Tips
+## 💡 Practical Tips
 
 ### Give the agent project context
 
@@ -280,7 +568,11 @@ use `normal` regardless of active mode.
 
 ______________________________________________________________________
 
-## Development
+More info: [docs/product/roadmap.md](docs/product/roadmap.md), [docs/architecture/architecture.md](docs/architecture/architecture.md)
+
+______________________________________________________________________
+
+## 🛠️ Development
 
 Requires **Poetry** and **Python 3.11-3.14**.
 
@@ -334,7 +626,7 @@ poetry run vstack install
 
 ______________________________________________________________________
 
-## Repository Structure
+## 🗂️ Repository Structure
 
 ```text
 vstack/
@@ -359,7 +651,7 @@ vstack/
 
 ______________________________________________________________________
 
-## CI and Release Automation
+## 🚦 CI and Release Automation
 
 | Workflow       | Trigger                       | Purpose                                                     |
 | -------------- | ----------------------------- | ----------------------------------------------------------- |
@@ -384,56 +676,7 @@ Recommended branch protection for `main`:
 
 ______________________________________________________________________
 
-## Troubleshooting
-
-### Agents are not appearing
-
-1. Run `vstack install --global` or `poetry run vstack install --global`
-1. Confirm the templates exist under `src/vstack/_templates/agents/`
-1. Reload VS Code with `Developer: Reload Window`
-
-### Agent is not running commands
-
-Make sure Copilot is in Agent Mode, not Ask or Edit mode.
-
-### Best-practice local workflow
-
-1. Run `make bootstrap` once per machine or clone.
-1. Run `make check` before every commit.
-1. Run `make ci` when you want to mirror the main quality gate locally.
-
-### Search results are noisy
-
-Use workspace-local exclusions in VS Code:
-
-```json
-{
-	"search.exclude": {
-		"**/.venv": true,
-		"**/venv": true,
-		"**/env": true,
-		"**/node_modules": true,
-		"**/__pycache__": true,
-		"**/dist": true,
-		"**/build": true,
-		"**/.git": true
-	},
-	"files.watcherExclude": {
-		"**/.venv/**": true,
-		"**/venv/**": true,
-		"**/env/**": true,
-		"**/node_modules/**": true,
-		"**/__pycache__/**": true,
-		"**/dist/**": true,
-		"**/build/**": true,
-		"**/.git/**": true
-	}
-}
-```
-
-______________________________________________________________________
-
-## Further Reading
+## 📚 Further Reading
 
 - [docs/architecture/architecture.md](docs/architecture/architecture.md)
 - [docs/design/design.md](docs/design/design.md)
@@ -444,6 +687,6 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## License
+## 📄 License
 
 MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     <img src="assets/branding/vstack.png" alt="vstack" width="400">
   </picture>
 
+[![PyPI version](https://img.shields.io/pypi/v/vstack?color=0B8A6F "Latest PyPI release")](https://pypi.org/project/vstack/)
 [![Python version](https://img.shields.io/badge/python-3.11--3.14-0B8A6F "Supported Python versions")](pyproject.toml)
 [![Verify status](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/verify.yml?branch=main&label=verify&color=1D6FA5 "Build and test status")](https://github.com/eschaar/vstack/actions/workflows/verify.yml)
 [![Security checks](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/security.yml?branch=main&label=security&color=B15E00 "Security workflow status")](https://github.com/eschaar/vstack/actions/workflows/security.yml)
@@ -63,7 +64,7 @@ For experienced users:
 #### New user path (2 minutes)
 
 ```bash
-pipx install git+https://github.com/eschaar/vstack.git
+pipx install vstack
 vstack install --target /path/to/your/project
 vstack validate
 ```
@@ -104,10 +105,12 @@ ______________________________________________________________________
 
 ### ⚡ Install with pipx (recommended)
 
-You can install and use vstack directly without cloning:
+`pipx` installs vstack in its own isolated environment so it never conflicts with
+your project dependencies. The `vstack` command is then available globally across
+all projects, regardless of which virtual environment is active.
 
 ```bash
-pipx install git+https://github.com/eschaar/vstack.git
+pipx install vstack
 ```
 
 Afterwards, the `vstack` command is available everywhere:
@@ -118,6 +121,21 @@ vstack install --target /path/to/your/project
 
 # Optional: install profile-wide defaults for all VS Code projects
 vstack install --global
+```
+
+### 🐙 Alternative: install directly from GitHub
+
+To install the latest unreleased version directly from the repository without cloning:
+
+```bash
+pipx install git+https://github.com/eschaar/vstack.git
+```
+
+Or a specific branch or tag:
+
+```bash
+pipx install git+https://github.com/eschaar/vstack.git@main
+pipx install git+https://github.com/eschaar/vstack.git@1.3.0
 ```
 
 ### 🐙 Alternative: manual clone and install
@@ -163,7 +181,7 @@ If you see the version and no errors, your install is working.
 Expected output (example):
 
 ```text
-vstack 1.2.5
+vstack 1.3.0
 Validation passed: no unresolved template tokens
 ```
 
@@ -430,7 +448,7 @@ flowchart TD
 - Issue: `Permission denied` during install or uninstall
   Action: Check directory permissions and rerun with appropriate privileges.
 - Issue: `Could not detect VS Code user data directory`
-  Action: Run with an explicit target, for example `vstack install --target ~/.config/Code/User`.
+  Action: Run `vstack install --global` to install into the VS Code user profile, or run `vstack install --target /path/to/your/project` to install into a specific project instead.
 
 ### Copilot Agent Mode
 

--- a/docs/architecture/adr/001-vscode-native-variant.md
+++ b/docs/architecture/adr/001-vscode-native-variant.md
@@ -13,7 +13,7 @@ automation — unsuitable for backend/microservice workflows where browser autom
 irrelevant.
 
 VS Code + GitHub Copilot is a dominant development environment that lacked an equivalent
-system. Modern models (Claude Sonnet/Opus 4.6, GPT-5.3 Codex) can execute multi-step
+system. Modern models (Claude Sonnet/Opus 4.6+, GPT-5.3 Codex) can execute multi-step
 workflows via VS Code Agent Mode.
 
 ## decision

--- a/src/vstack/_templates/agents/architect/config.yaml
+++ b/src/vstack/_templates/agents/architect/config.yaml
@@ -18,9 +18,9 @@ tools:
   - todo
   - agent
 model:
-  - Claude Opus 4.6 (copilot)
   - Claude Sonnet 4.6 (copilot)
   - GPT-5.3-Codex (copilot)
+  - Claude Opus 4.7 (copilot)
 agents: ["*"]
 handoffs:
   - label: Continue to design

--- a/src/vstack/_templates/agents/product/config.yaml
+++ b/src/vstack/_templates/agents/product/config.yaml
@@ -17,8 +17,8 @@ tools:
   - agent
 model:
   - Claude Sonnet 4.6 (copilot)
-  - Claude Opus 4.6 (copilot)
   - GPT-5.3-Codex (copilot)
+  - Claude Opus 4.7 (copilot)
 agents: ["*"]
 handoffs:
   - label: Continue to architecture

--- a/tests/vstack/agents/test_generation.py
+++ b/tests/vstack/agents/test_generation.py
@@ -26,9 +26,9 @@ class TestAgentGeneration:
 
         assert parsed.metadata.get("name") == "architect"
         assert parsed.metadata.get("model") == [
-            "Claude Opus 4.6 (copilot)",
             "Claude Sonnet 4.6 (copilot)",
             "GPT-5.3-Codex (copilot)",
+            "Claude Opus 4.7 (copilot)",
         ]
 
         handoffs = parsed.metadata.get("handoffs")

--- a/tests/vstack/cli/test_commands.py
+++ b/tests/vstack/cli/test_commands.py
@@ -62,13 +62,13 @@ class TestCommandLineInterface:
             f"vstack verify --only skill failed:\n{result.stdout}\n{result.stderr}"
         )
 
-    def test_install_and_verify_exits_zero(self) -> None:
+    def test_install_and_verify_exits_zero(self, tmp_path: Path) -> None:
         """Test that install and verify exits zero."""
-        install = run_vstack(["install"])
+        install = run_vstack(["install", "--target", str(tmp_path)])
         assert install.returncode == 0, (
             f"vstack install failed:\n{install.stdout}\n{install.stderr}"
         )
-        verify = run_vstack(["verify"])
+        verify = run_vstack(["verify", "--target", str(tmp_path)])
         assert verify.returncode == 0, f"vstack verify failed:\n{verify.stdout}\n{verify.stderr}"
 
     def test_validate_with_empty_templates_returns_non_zero(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

DX, onboarding, and PyPI publishing release.

- Improved README onboarding flow: team setup guidance, expected output examples, troubleshooting flowchart, quick navigation, pipx rationale, and GitHub install alternative
- Added GitHub Discussion templates: `onboarding-feedback`, `first-run-report`, `model-cost-feedback`
- Added PyPI publish job to release workflow using OIDC trusted publishing (no API tokens)
- Added PyPI badge and updated install instructions in README to `pipx install vstack`
- Updated architect and product agent model list (Opus 4.7)
- Fixed test `test_install_and_verify_exits_zero` writing to repo root instead of `tmp_path`
- Simplified release workflow job names: `release`, `build`, `publish`
- Fixed `build` job missing `fetch-depth: 0` (needed for `poetry-dynamic-versioning`)
- Fixed `download-artifact@v5` / `upload-artifact@v7` version mismatch → both now `v7`

## Related Issues

N/A

## Validation

- [x] Tests pass locally
- [x] CI checks pass
- [x] Docs updated (if needed)

## Release Impact

- [ ] `fix:` (patch) — bug fixes in test isolation and workflow
- [x] `feat:` (minor) — PyPI publishing, DX improvements