### PR TITLE
fix(ci): build release artifacts from computed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,8 +128,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Full history and tags required by poetry-dynamic-versioning.
-          fetch-depth: 0
+          # Build from the newly created release tag to guarantee package version.
+          ref: refs/tags/${{ needs.release.outputs.version }}
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install Poetry
         run: pipx install poetry
@@ -141,8 +143,31 @@ jobs:
           cache: poetry
           cache-dependency-path: poetry.lock
 
+      - name: Validate release tag checkout
+        run: |
+          EXPECTED="${{ needs.release.outputs.version }}"
+          ACTUAL_TAG="$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+          echo "expected_tag=$EXPECTED"
+          echo "head_tag=$ACTUAL_TAG"
+          if [[ "$ACTUAL_TAG" != "$EXPECTED" ]]; then
+            echo "ERROR: build checkout is not pinned to expected release tag.";
+            exit 1
+          fi
+
       - name: Build distributions
         run: poetry build
+
+      - name: Validate built artifact version
+        run: |
+          EXPECTED="${{ needs.release.outputs.version }}"
+          shopt -s nullglob
+          MATCHES=(dist/*"$EXPECTED"*.whl dist/*"$EXPECTED"*.tar.gz)
+          echo "expected_version=$EXPECTED"
+          ls -1 dist/
+          if [[ ${#MATCHES[@]} -eq 0 ]]; then
+            echo "ERROR: no built artifacts contain expected version '$EXPECTED'."
+            exit 1
+          fi
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.3.2 - 2026-04-22
+
+Release build version-guard fix.
+
+### Fixed in 1.3.2
+
+- Fixed release build determinism by checking out `refs/tags/<version>` in the build job instead of building from a moving branch ref.
+- Fixed accidental `0.0.0` package publishing by validating that HEAD is pinned to the expected release tag before build and that produced artifacts include the expected version.
+
 ## 1.3.1 - 2026-04-22
 
 Release workflow and test isolation fixes.


### PR DESCRIPTION
## Summary

Fix release packaging determinism to prevent publishing incorrect versions to PyPI.

- Updated release build job to checkout the computed release tag (`refs/tags/${{ needs.release.outputs.version }}`) instead of building from a moving branch ref.
- Added a pre-build version guard that compares `poetry version -s` against the computed release version and fails fast on mismatch.
- Updated changelog to include this fix under `1.3.2`.

## Related Issues

- PyPI publish used incorrect package version (`0.0.0`) instead of the intended release version.

## Validation

- [x] Tests pass locally
- [ ] CI checks pass
- [x] Docs updated (if needed)

## Release Impact

- [x] `fix:` (patch)
- [ ] `feat:` (minor)
- [ ] `BREAKING CHANGE` (major)
- [ ] No release impact