### PR TITLE
Fix/release plugin

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -15,6 +15,8 @@ permissions:
 env:
   # Baseline interpreter for non-matrix checks.
   PYTHON_VERSION: "3.11"
+  # Pin Poetry CLI version for deterministic CI behavior.
+  POETRY_VERSION: "2.3.4"
   # Keep Poetry virtual environments inside the workspace for deterministic paths.
   POETRY_VIRTUALENVS_IN_PROJECT: "true"
 
@@ -29,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install "poetry==${POETRY_VERSION}"
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -64,7 +66,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install "poetry==${POETRY_VERSION}"
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ permissions:
 env:
   # Shared interpreter version for build and metadata steps.
   PYTHON_VERSION: "3.11"
+  # Pin Poetry CLI version for deterministic release builds.
+  POETRY_VERSION: "2.3.4"
   # Opt in to Node.js 24 for JavaScript-based actions ahead of runner defaults.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -76,33 +78,22 @@ jobs:
           echo "changed=${{ steps.version.outputs.changed }}"
           echo "version=${{ steps.version.outputs.version }}"
 
-      - name: Enforce no-v SemVer tags
-        if: steps.version.outputs.changed == 'true'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # Repository policy: tags must be plain SemVer (for example 1.0.0), never v1.0.0.
-          if [[ "$VERSION" =~ ^v ]]; then
-            echo "ERROR: release tag must not start with 'v' (got '$VERSION')."
-            exit 1
-          fi
-
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: release tag must match X.Y.Z (got '$VERSION')."
-            exit 1
-          fi
-
       - name: Create and push git tag
         if: steps.version.outputs.changed == 'true'
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "ERROR: release tag must match X.Y.Z without a v-prefix (got '$VERSION')."
+            exit 1
+          }
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1 && {
-            echo "ERROR: tag '${{ steps.version.outputs.version }}' already exists.";
+          git rev-parse "$VERSION" >/dev/null 2>&1 && {
+            echo "ERROR: tag '$VERSION' already exists.";
             exit 1;
           }
-          git tag -a "${{ steps.version.outputs.version }}" -m "release ${{ steps.version.outputs.version }}"
-          git push origin "${{ steps.version.outputs.version }}"
+          git tag -a "$VERSION" -m "release $VERSION"
+          git push origin "$VERSION"
 
       - name: Compute release date
         if: steps.version.outputs.changed == 'true'
@@ -135,7 +126,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install poetry
+          pipx install "poetry==${POETRY_VERSION}"
           pipx inject poetry "poetry-dynamic-versioning[plugin]>=1.0.0,<2.0.0"
 
       - name: Show Poetry plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,12 @@ jobs:
           fetch-tags: true
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: |
+          pipx install poetry
+          pipx inject poetry "poetry-dynamic-versioning[plugin]>=1.0.0,<2.0.0"
+
+      - name: Show Poetry plugins
+        run: poetry self show plugins
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,8 @@ permissions:
 env:
   # Keep scanner runtime consistent across runs.
   PYTHON_VERSION: "3.11"
+  # Pin Poetry CLI version for deterministic CI behavior.
+  POETRY_VERSION: "2.3.4"
 
 jobs:
   security:
@@ -27,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install "poetry==${POETRY_VERSION}"
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,8 @@ permissions:
 env:
   # Shared interpreter version for reproducible CI behavior.
   PYTHON_VERSION: "3.11"
+  # Pin Poetry CLI version for deterministic CI behavior.
+  POETRY_VERSION: "2.3.4"
   # Keep Poetry virtual environments inside the workspace for deterministic paths.
   POETRY_VIRTUALENVS_IN_PROJECT: "true"
 
@@ -28,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install "poetry==${POETRY_VERSION}"
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -53,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install "poetry==${POETRY_VERSION}"
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.3.3 - 2026-04-22
+
+Release build plugin activation fix.
+
+### Fixed in 1.3.3
+
+- Fixed CI release builds producing `0.0.0` artifacts by installing/enabling `poetry-dynamic-versioning` in the Poetry runtime used by the build job.
+- Fixed release build reproducibility by pinning the Poetry CLI version in workflow environment configuration.
+- Fixed CI drift by aligning Poetry installation to the same pinned version across `release.yml`, `qa.yml`, `verify.yml`, and `security.yml`.
+- Fixed release workflow noise by inlining SemVer format validation into the tag creation step.
+- Added Poetry plugin visibility in release logs via `poetry self show plugins` to simplify troubleshooting.
+
 ## 1.3.2 - 2026-04-22
 
 Release build version-guard fix.
@@ -7,7 +19,7 @@ Release build version-guard fix.
 ### Fixed in 1.3.2
 
 - Fixed release build determinism by checking out `refs/tags/<version>` in the build job instead of building from a moving branch ref.
-- Fixed accidental `0.0.0` package publishing by installing/enabling `poetry-dynamic-versioning` in the CI Poetry runtime and validating that both HEAD tag and built artifact version match the computed release version.
+- Fixed accidental `0.0.0` package publishing by validating that HEAD is pinned to the expected release tag before build and that produced artifacts include the expected version.
 
 ## 1.3.1 - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Release build version-guard fix.
 ### Fixed in 1.3.2
 
 - Fixed release build determinism by checking out `refs/tags/<version>` in the build job instead of building from a moving branch ref.
-- Fixed accidental `0.0.0` package publishing by validating that HEAD is pinned to the expected release tag before build and that produced artifacts include the expected version.
+- Fixed accidental `0.0.0` package publishing by installing/enabling `poetry-dynamic-versioning` in the CI Poetry runtime and validating that both HEAD tag and built artifact version match the computed release version.
 
 ## 1.3.1 - 2026-04-22
 


### PR DESCRIPTION
## Summary

Hardened release packaging/versioning and aligned Poetry installation across CI workflows.

- Fixed release tag creation flow with compact in-step SemVer validation (X.Y.Z without `v` prefix) in `release.yml`.
- Pinned Poetry CLI version via `POETRY_VERSION` and upgraded pin to `2.3.4`.
- Enabled `poetry-dynamic-versioning` plugin in release build runtime to prevent fallback `0.0.0` artifacts.
- Added plugin visibility step (`poetry self show plugins`) for easier CI troubleshooting.
- Kept release build safeguards:
  - checkout pinned to `refs/tags/${{ needs.release.outputs.version }}`
  - tag checkout validation before build
  - built artifact version validation after build
- Aligned Poetry installation to the same pinned version across:
  - `release.yml`
  - `qa.yml`
  - `verify.yml`
  - `security.yml`
- Updated `CHANGELOG.md` with `1.3.3` entries matching these workflow fixes.

## Related Issues

- PyPI release produced `0.0.0` artifacts instead of expected SemVer tag version.

## Validation

- [x] Tests pass locally
- [ ] CI checks pass
- [x] Docs updated (if needed)

## Release Impact

- [x] `fix:` (patch)
- [ ] `feat:` (minor)
- [ ] `BREAKING CHANGE` (major)
- [ ] No release impact