### PR TITLE
fix(ci): align dynamic version config for 1.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.3.5 - 2026-04-22
+
+Release version resolution compatibility fixes.
+
+### Fixed in 1.3.5
+
+- Fixed `poetry dynamic-versioning` CI failures by removing unsupported `tool.poetry-dynamic-versioning.fallback-version` config.
+- Fixed release builds resolving to `0.0.0` by switching to `project.dynamic = ["version"]` and moving the placeholder version to `tool.poetry.version`, so `poetry-dynamic-versioning` can inject the computed tag version correctly.
+- Fixed `pyproject.toml` inline documentation to reflect current fallback behavior when no git tag is reachable.
+
 ## 1.3.4 - 2026-04-22
 
 Release build versioning fix: explicit plugin activation and full history checkout.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vstack"
-version = "0.0.0"
+dynamic = ["version"]
 description = "VS Code-native AI engineering workflow system for microservices, libraries, and backend systems."
 license = "MIT"
 readme = "README.md"
@@ -16,6 +16,7 @@ vstack = "vstack:main"
 # ---------------------------------------------------------------------------
 
 [tool.poetry]
+version = "0.0.0"
 packages = [{include = "vstack", from = "src"}]
 include = [
     { path = "src/vstack/_templates", format = ["sdist", "wheel"] },
@@ -86,14 +87,14 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 # ---------------------------------------------------------------------------
 # poetry-dynamic-versioning — reads version from git tags at build time.
-# Fallback is used when no git tag is reachable (e.g. shallow clone, fresh repo).
+# If no git tag is reachable (e.g. shallow clone, fresh repo), the placeholder
+# `tool.poetry.version` value (`0.0.0`) remains in effect.
 # ---------------------------------------------------------------------------
 
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
 style = "pep440"
-fallback-version = "0.0.0"
 
 # ---------------------------------------------------------------------------
 # pyright is used for type checking in VS Code, by Pylance.


### PR DESCRIPTION
## Summary

Fixes dynamic version resolution for release builds by aligning `pyproject.toml` with `poetry-dynamic-versioning` expectations and moves the related release notes to `1.3.5` in `CHANGELOG.md`.

- Replaced `project.version = "0.0.0"` with `project.dynamic = ["version"]`.
- Added `tool.poetry.version = "0.0.0"` as the placeholder version source for Poetry.
- Removed unsupported `tool.poetry-dynamic-versioning.fallback-version`.
- Updated changelog entries so these fixes are tracked under `1.3.5` instead of `1.3.4`.

## Why

Release builds were resolving to `0.0.0` despite dynamic versioning being enabled.  
The project metadata layout was not aligned with how `poetry-dynamic-versioning` injects the computed tag version in this setup.

## Version impact
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major