### PR TITLE
fix(release): remove bypass and enforce tag-based dynamic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,9 +141,6 @@ jobs:
       - name: Show active Poetry plugins
         run: poetry self show plugins
 
-      - name: Apply dynamic version
-        run: poetry dynamic-versioning
-
       - name: Build distributions
         run: poetry build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.3.6 - 2026-04-22
+
+Release build determinism fix.
+
+### Fixed in 1.3.6
+
+- Fixed release version resolution by relying on strict tag-based dynamic versioning instead of a CI-only bypass override.
+- Fixed dynamic version resolution for this repository's unprefixed tags by setting `tool.poetry-dynamic-versioning.pattern = "default-unprefixed"`.
+- Fixed dynamic versioning misconfiguration by enabling `tool.poetry-dynamic-versioning.strict = true`, so CI fails instead of silently falling back to `0.0.0` when no valid tag is found.
+- Added `tool.poetry.requires-plugins` so Poetry 2.x installations know the project requires `poetry-dynamic-versioning[plugin]`.
+- Reduced configuration churn in PEP 621 mode by moving `tool.poetry.version` to the bottom of the `[tool.poetry]` table, matching the plugin's documented behavior.
+
 ## 1.3.5 - 2026-04-22
 
 Release version resolution compatibility fixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,16 @@ vstack = "vstack:main"
 # ---------------------------------------------------------------------------
 
 [tool.poetry]
-version = "0.0.0"
 packages = [{include = "vstack", from = "src"}]
 include = [
     { path = "src/vstack/_templates", format = ["sdist", "wheel"] },
 ]
+# Keep the placeholder version last because the plugin may remove/re-add it in
+# PEP 621 mode, which otherwise causes noisy key reordering.
+version = "0.0.0"
+
+[tool.poetry.requires-plugins]
+poetry-dynamic-versioning = { version = ">=1.0.0,<2.0.0", extras = ["plugin"] }
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.0"
@@ -87,13 +92,17 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 # ---------------------------------------------------------------------------
 # poetry-dynamic-versioning — reads version from git tags at build time.
-# If no git tag is reachable (e.g. shallow clone, fresh repo), the placeholder
-# `tool.poetry.version` value (`0.0.0`) remains in effect.
+# With `strict = true`, build/version resolution fails when no valid tag/version
+# can be resolved (e.g. shallow clone, missing tags, or non-matching tag format).
+# The placeholder `tool.poetry.version` value (`0.0.0`) is not used as fallback.
 # ---------------------------------------------------------------------------
 
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
+# Repository tags are plain SemVer without a leading v (e.g. 1.3.4).
+pattern = "default-unprefixed"
+strict = true
 style = "pep440"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removed release-time bypass override so package versioning resolves from git tags via poetry-dynamic-versioning configuration.
- Kept CI plugin installation and tag-pinned checkout flow, while removing the redundant dynamic-versioning command step.
- Updated project packaging config for cleaner Poetry/PEP 621 behavior and aligned changelog notes with the final strategy.

## Why
The release pipeline must fail fast on versioning misconfiguration instead of silently producing incorrect versions.  
By relying on strict tag-based configuration (including unprefixed tag matching) instead of a CI-only override, releases become deterministic and easier to reason about.

## Version impact
- [x] Patch
- [ ] Minor
- [ ] Major
- [ ] None