### PR TITLE
chore(docs): align badges and header layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.3.6 - 2026-04-22
+
+README and PyPI README badge/layout alignment.
+
+### Fixed in 1.3.6
+
+- Fixed oversized logo rendering in `README-pypi.md` by constraining image width.
+- Fixed duplicate title/branding in `README-pypi.md` by removing redundant `# vstack` heading.
+- Fixed badge ordering so badges render beneath the logo in `README-pypi.md`.
+- Fixed PyPI version badge formatting in both `README.md` and `README-pypi.md` to show the raw version (no `v` prefix).
+- Fixed verify/security workflow badges in both `README.md` and `README-pypi.md` by removing `branch=main` filter so PR-based workflows report status correctly.
+
 ## 1.3.5 - 2026-04-22
 
 Changelog and PyPI packaging metadata alignment update.

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -1,14 +1,14 @@
-# vstack
+<p align="center">
+	<img src="https://raw.githubusercontent.com/eschaar/vstack/main/assets/branding/vstack.png" alt="vstack" width="260">
+</p>
 
-[![PyPI version](https://img.shields.io/pypi/v/vstack?color=0B8A6F)](https://pypi.org/project/vstack/)
+[![PyPI version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fpypi.org%2Fpypi%2Fvstack%2Fjson&query=%24.info.version&label=PyPI&color=0B8A6F&cacheSeconds=300)](https://pypi.org/project/vstack/)
 [![Python version](https://img.shields.io/badge/python-3.11--3.14-0B8A6F)](https://github.com/eschaar/vstack/blob/main/pyproject.toml)
-[![Verify status](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/verify.yml?branch=main&label=verify&color=1D6FA5)](https://github.com/eschaar/vstack/actions/workflows/verify.yml)
-[![Security checks](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/security.yml?branch=main&label=security&color=B15E00)](https://github.com/eschaar/vstack/actions/workflows/security.yml)
+[![Verify status](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/verify.yml?label=verify&color=1D6FA5)](https://github.com/eschaar/vstack/actions/workflows/verify.yml)
+[![Security checks](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/security.yml?label=security&color=B15E00)](https://github.com/eschaar/vstack/actions/workflows/security.yml)
 [![Runtime: stdlib only](https://img.shields.io/badge/runtime-stdlib%20only-5B6C8F)](https://github.com/eschaar/vstack/blob/main/pyproject.toml)
 [![License: MIT](https://img.shields.io/github/license/eschaar/vstack?color=5F7A1F)](https://github.com/eschaar/vstack/blob/main/LICENSE)
 [![GitHub Discussions](https://img.shields.io/badge/discussions-ask%20%26%20share-blueviolet?logo=github)](https://github.com/eschaar/vstack/discussions)
-
-![vstack logo](https://raw.githubusercontent.com/eschaar/vstack/main/assets/branding/vstack.png)
 
 The VS Code-native AI workflow system for backend engineering.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
     <img src="assets/branding/vstack.png" alt="vstack" width="400">
   </picture>
 
-[![PyPI version](https://img.shields.io/pypi/v/vstack?color=0B8A6F "Latest PyPI release")](https://pypi.org/project/vstack/)
+[![PyPI version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fpypi.org%2Fpypi%2Fvstack%2Fjson&query=%24.info.version&label=PyPI&color=0B8A6F&cacheSeconds=300 "Latest PyPI release")](https://pypi.org/project/vstack/)
 [![Python version](https://img.shields.io/badge/python-3.11--3.14-0B8A6F "Supported Python versions")](pyproject.toml)
-[![Verify status](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/verify.yml?branch=main&label=verify&color=1D6FA5 "Build and test status")](https://github.com/eschaar/vstack/actions/workflows/verify.yml)
-[![Security checks](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/security.yml?branch=main&label=security&color=B15E00 "Security workflow status")](https://github.com/eschaar/vstack/actions/workflows/security.yml)
+[![Verify status](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/verify.yml?label=verify&color=1D6FA5 "Build and test status")](https://github.com/eschaar/vstack/actions/workflows/verify.yml)
+[![Security checks](https://img.shields.io/github/actions/workflow/status/eschaar/vstack/security.yml?label=security&color=B15E00 "Security workflow status")](https://github.com/eschaar/vstack/actions/workflows/security.yml)
 [![Runtime: stdlib only](https://img.shields.io/badge/runtime-stdlib%20only-5B6C8F "No runtime dependencies")](pyproject.toml)
 [![License: MIT](https://img.shields.io/github/license/eschaar/vstack?color=5F7A1F "Project license")](LICENSE)
 [![GitHub Discussions](https://img.shields.io/badge/discussions-ask%20%26%20share-blueviolet?logo=github "GitHub Discussions")](https://github.com/eschaar/vstack/discussions)


### PR DESCRIPTION
## Summary
- Updated README and README-pypi badge/header rendering for consistency and correct status display.
- Fixed PyPI version badge formatting to show the raw version value (no `v` prefix).
- Fixed Verify/Security badges to show workflow status correctly for PR-triggered workflows.
- Updated changelog with a new `1.3.6` section documenting these documentation and badge fixes.

## Why
- PyPI badge formatting and workflow badge status behavior were confusing (version prefix mismatch and “no status” behavior).
- README-pypi header layout had visual issues (oversized logo, redundant title, badge placement).
- Changelog needed an explicit `1.3.6` entry to capture these shipped documentation fixes.

## Version impact
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major