### PR TITLE
Fix/release manifest guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
     assignees:
       - "eschaar"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 6
     labels:
       - "dependencies"
       - "python"
@@ -26,7 +26,7 @@ updates:
       interval: "weekly"
     assignees:
       - "eschaar"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 6
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
     assignees:
       - "eschaar"
-    open-pull-requests-limit: 6
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "python"
@@ -23,10 +23,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     assignees:
       - "eschaar"
-    open-pull-requests-limit: 6
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Approve eligible PR
         if: steps.decision.outputs.should_automerge == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -65,7 +65,7 @@ jobs:
 
       - name: Update branch for eligible PR
         if: steps.decision.outputs.should_automerge == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -93,7 +93,7 @@ jobs:
 
       - name: Enable auto-merge for eligible PR
         if: steps.decision.outputs.should_automerge == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -63,6 +63,34 @@ jobs:
               body: "Auto-approved for safe Dependabot update policy."
             })
 
+      - name: Update branch for eligible PR
+        if: steps.decision.outputs.should_automerge == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Intentional strategy:
+            // - Always request an update for eligible PRs instead of pre-checking merge state.
+            // - GitHub may report transient/unknown merge state during event handling.
+            // - updateBranch is idempotent; if already current, GitHub returns a benign 422/no-op.
+            // This keeps automerge flow deterministic without relying on flaky preconditions.
+            try {
+              await github.rest.pulls.updateBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number
+              })
+              core.info("Requested branch update from base branch.")
+            } catch (error) {
+              const msg = String(error.message || "")
+              if (error.status === 422 || msg.includes("not behind")) {
+                // Expected no-op path when branch is already up to date.
+                core.info("Branch already up to date; continuing.")
+              } else {
+                core.setFailed("Could not update branch before automerge. " + msg)
+              }
+            }
+
       - name: Enable auto-merge for eligible PR
         if: steps.decision.outputs.should_automerge == 'true'
         uses: actions/github-script@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,15 @@ jobs:
             exit 0
           fi
 
-          if [[ "$manifest_version" != "$latest_tag" ]]; then
-            echo "ERROR: .release-please-manifest.json is stale."
+          if [[ ! "$manifest_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: invalid .release-please-manifest.json version: $manifest_version"
+            exit 1
+          fi
+
+          # A merged release-please PR can make manifest_version temporarily newer than latest_tag.
+          # That state is valid; only fail if manifest_version is behind the newest existing tag.
+          if [[ "$(printf '%s\n%s\n' "$latest_tag" "$manifest_version" | sort -V | tail -n 1)" == "$latest_tag" && "$manifest_version" != "$latest_tag" ]]; then
+            echo "ERROR: .release-please-manifest.json is stale (behind latest tag)."
             echo "manifest version: $manifest_version"
             echo "latest git tag:   $latest_tag"
             echo "Update .release-please-manifest.json before running release orchestration."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,10 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          # v3 requires the GitHub App client ID.
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,23 @@
 
 ## [2.0.3](https://github.com/eschaar/vstack/compare/2.0.2...2.0.3) (2026-04-28)
 
+### Maintenance
+
+- **ci:** harden release workflows and normalize changelog ([5a38709](https://github.com/eschaar/vstack/commit/5a387091dcea8dc7545bda5430fd02aee88ac0af))
+- **ci:** restructure pipeline with release-please and GitHub App token ([8c06090](https://github.com/eschaar/vstack/commit/8c060906ae7d8a662ff1e772fa531484eafb1067))
+- **ci:** restructure pipeline with release-please and GitHub App token ([#30](https://github.com/eschaar/vstack/issues/30)) ([0008127](https://github.com/eschaar/vstack/commit/0008127fafbf261fbbf6363fe9a4eb7769edfe83))
+
+## [2.0.2](https://github.com/eschaar/vstack/compare/2.0.1...2.0.2) (2026-04-27)
 
 ### Maintenance
 
-* **ci:** harden release workflows and normalize changelog ([5a38709](https://github.com/eschaar/vstack/commit/5a387091dcea8dc7545bda5430fd02aee88ac0af))
-* **ci:** restructure pipeline with release-please and GitHub App token ([8c06090](https://github.com/eschaar/vstack/commit/8c060906ae7d8a662ff1e772fa531484eafb1067))
-* **ci:** restructure pipeline with release-please and GitHub App token ([#30](https://github.com/eschaar/vstack/issues/30)) ([0008127](https://github.com/eschaar/vstack/commit/0008127fafbf261fbbf6363fe9a4eb7769edfe83))
+- **ci:** bump trufflesecurity/trufflehog from 3.94.3 to 3.95.2 ([#25](https://github.com/eschaar/vstack/issues/25)) ([5724dbe](https://github.com/eschaar/vstack/commit/5724dbe605523da2c90a4f143fa8c4a92322adf4))
+
+## [2.0.1](https://github.com/eschaar/vstack/compare/2.0.0...2.0.1) (2026-04-27)
+
+### Maintenance
+
+- **ci:** bump actions/download-artifact from 7 to 8 ([#26](https://github.com/eschaar/vstack/issues/26)) ([24d5a58](https://github.com/eschaar/vstack/commit/24d5a585c37fe8097de41863e0085917e81a376f))
 
 ## 2.0.0 (2026-04-26)
 


### PR DESCRIPTION
Title: chore(ci): stabilize release pipeline and dependency automation

## Summary
- Fixes release orchestration so manifest/tag drift checks no longer block valid pending releases.
- Migrates GitHub App token generation to create-github-app-token v3 using client-id secret input.
- Improves Dependabot automation by updating eligible PR branches before enabling auto-merge.
- Upgrades automerge workflow action dependencies (fetch-metadata and github-script).
- Updates Dependabot policy:
  - github-actions checks daily
  - open PR limits tuned to 5 for both github-actions and pip
- Restores and normalizes 2.0.x changelog entries in release-please style.

## Why
- Release 2.0.3 was stuck: release workflow failed before release-please execution, so no GitHub release was published and publish workflow never triggered.
- Dependabot PRs could remain behind main, reducing auto-merge reliability.
- Dependency automation needed tighter, clearer policy while keeping CI usage under control.
- Changelog needed consistency and completeness for the 2.0.x sequence.

## Version impact
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major