### PR TITLE
fix(ci): install wheel dependencies in publish smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Smoke test built wheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --no-deps dist/*.whl
+          python -m pip install dist/*.whl
           vstack --help >/dev/null
 
       - name: Validate built artifact version


### PR DESCRIPTION
The publish smoke test installed dist/*.whl with --no-deps and then ran vstack --help. Since vstack imports yaml at startup, the runtime dependency PyYAML was missing and the step failed with ModuleNotFoundError.

Install the wheel normally so runtime dependencies are resolved during the smoke test.