### PR TITLE
fix(ci): harden Homebrew publish workflow auth and environment separation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     env:
-      HOMEBREW_TAP_APP_ID: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+      HOMEBREW_TAP_APP_CLIENT_ID: ${{ secrets.HOMEBREW_TAP_APP_CLIENT_ID }}
       HOMEBREW_TAP_APP_PRIVATE_KEY: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
       HOMEBREW_TAP_DISPATCH_SECRET: ${{ secrets.HOMEBREW_TAP_DISPATCH_SECRET }}
 
@@ -186,8 +186,8 @@ jobs:
       - name: Verify Homebrew tap dispatch configuration
         shell: bash
         run: |
-          if [[ -z "$HOMEBREW_TAP_APP_ID" ]]; then
-            echo "ERROR: HOMEBREW_TAP_APP_ID is not configured in the pypi environment."
+          if [[ -z "$HOMEBREW_TAP_APP_CLIENT_ID" ]]; then
+            echo "ERROR: HOMEBREW_TAP_APP_CLIENT_ID is not configured in the pypi environment."
             exit 1
           fi
 
@@ -205,7 +205,7 @@ jobs:
         id: create_tap_token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         with:
-          app-id: ${{ env.HOMEBREW_TAP_APP_ID }}
+          client-id: ${{ env.HOMEBREW_TAP_APP_CLIENT_ID }}
           private-key: ${{ env.HOMEBREW_TAP_APP_PRIVATE_KEY }}
           owner: ${{ env.HOMEBREW_TAP_REPOSITORY_OWNER }}
           repositories: ${{ env.HOMEBREW_TAP_REPOSITORY_NAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,7 +155,7 @@ jobs:
     # HOMEBREW_TAP_ENABLED (value: "true" to enable). Default/absent keeps this disabled.
     if: needs.publish.result == 'success' && github.event.release.prerelease == false && vars.HOMEBREW_TAP_ENABLED == 'true'
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: homebrew
     env:
       HOMEBREW_TAP_APP_CLIENT_ID: ${{ secrets.HOMEBREW_TAP_APP_CLIENT_ID }}
       HOMEBREW_TAP_APP_PRIVATE_KEY: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ env:
   HOMEBREW_TAP_ENABLED: "false"
   HOMEBREW_TAP_NAME: "eschaar/vstack"
   HOMEBREW_TAP_REPOSITORY: "eschaar/homebrew-vstack"
+  HOMEBREW_TAP_REPOSITORY_OWNER: "eschaar"
+  HOMEBREW_TAP_REPOSITORY_NAME: "homebrew-vstack"
   HOMEBREW_FORMULA_NAME: "vstack"
   HOMEBREW_FULLY_QUALIFIED_FORMULA: "eschaar/vstack/vstack"
 
@@ -155,7 +157,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     env:
-      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      HOMEBREW_TAP_APP_ID: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+      HOMEBREW_TAP_APP_PRIVATE_KEY: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
       HOMEBREW_TAP_DISPATCH_SECRET: ${{ secrets.HOMEBREW_TAP_DISPATCH_SECRET }}
 
     steps:
@@ -183,8 +186,13 @@ jobs:
       - name: Verify Homebrew tap dispatch configuration
         shell: bash
         run: |
-          if [[ -z "$HOMEBREW_TAP_TOKEN" ]]; then
-            echo "ERROR: HOMEBREW_TAP_TOKEN is not configured in the pypi environment."
+          if [[ -z "$HOMEBREW_TAP_APP_ID" ]]; then
+            echo "ERROR: HOMEBREW_TAP_APP_ID is not configured in the pypi environment."
+            exit 1
+          fi
+
+          if [[ -z "$HOMEBREW_TAP_APP_PRIVATE_KEY" ]]; then
+            echo "ERROR: HOMEBREW_TAP_APP_PRIVATE_KEY is not configured in the pypi environment."
             exit 1
           fi
 
@@ -192,6 +200,15 @@ jobs:
             echo "ERROR: HOMEBREW_TAP_DISPATCH_SECRET is not configured in the pypi environment."
             exit 1
           fi
+
+      - name: Create Homebrew tap app token
+        id: create_tap_token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ env.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ env.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: ${{ env.HOMEBREW_TAP_REPOSITORY_OWNER }}
+          repositories: ${{ env.HOMEBREW_TAP_REPOSITORY_NAME }}
 
       - name: Fetch sdist metadata and verify checksum
         id: verify_sdist
@@ -271,7 +288,7 @@ jobs:
 
           curl -fsS -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+            -H "Authorization: Bearer ${{ steps.create_tap_token.outputs.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${HOMEBREW_TAP_REPOSITORY}/dispatches" \
             --data-binary @dispatch-body.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,7 +149,9 @@ jobs:
   publish-homebrew:
     name: Update Homebrew Tap
     needs: publish
-    if: needs.publish.result == 'success' && github.event.release.prerelease == false && env.HOMEBREW_TAP_ENABLED == 'true'
+    # NOTE: job-level `if` cannot use the `env` context. Toggle via repository variable
+    # HOMEBREW_TAP_ENABLED (value: "true" to enable). Default/absent keeps this disabled.
+    if: needs.publish.result == 'success' && github.event.release.prerelease == false && vars.HOMEBREW_TAP_ENABLED == 'true'
     runs-on: ubuntu-latest
     environment: pypi
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,6 +188,11 @@ jobs:
             exit 1
           fi
 
+          if [[ -z "$HOMEBREW_TAP_DISPATCH_SECRET" ]]; then
+            echo "ERROR: HOMEBREW_TAP_DISPATCH_SECRET is not configured in the pypi environment."
+            exit 1
+          fi
+
       - name: Fetch sdist metadata and verify checksum
         id: verify_sdist
         shell: bash

--- a/tests/vstack/test_publish_workflow.py
+++ b/tests/vstack/test_publish_workflow.py
@@ -41,6 +41,13 @@ class TestPublishWorkflow:
         assert "https://pypi.org/pypi/vstack/" in verify_script
         assert "sha256 mismatch between PyPI metadata and downloaded tarball" in verify_script
 
+        config_step = next(
+            step for step in steps if step["name"] == "Verify Homebrew tap dispatch configuration"
+        )
+        config_script = config_step["run"]
+        assert "HOMEBREW_TAP_TOKEN" in config_script
+        assert "HOMEBREW_TAP_DISPATCH_SECRET" in config_script
+
         dispatch_step = next(
             step for step in steps if step["name"] == "Dispatch formula update to Homebrew tap"
         )

--- a/tests/vstack/test_publish_workflow.py
+++ b/tests/vstack/test_publish_workflow.py
@@ -29,7 +29,7 @@ class TestPublishWorkflow:
         job_if = homebrew_job["if"]
         assert "needs.publish.result == 'success'" in job_if
         assert "github.event.release.prerelease == false" in job_if
-        assert "env.HOMEBREW_TAP_ENABLED == 'true'" in job_if
+        assert "vars.HOMEBREW_TAP_ENABLED == 'true'" in job_if
 
     def test_homebrew_job_verifies_sdist_and_dispatches_update(self) -> None:
         """Homebrew publish should verify sdist checksum before repository dispatch."""

--- a/tests/vstack/test_publish_workflow.py
+++ b/tests/vstack/test_publish_workflow.py
@@ -47,7 +47,7 @@ class TestPublishWorkflow:
             step for step in steps if step["name"] == "Verify Homebrew tap dispatch configuration"
         )
         config_script = config_step["run"]
-        assert "HOMEBREW_TAP_APP_ID" in config_script
+        assert "HOMEBREW_TAP_APP_CLIENT_ID" in config_script
         assert "HOMEBREW_TAP_APP_PRIVATE_KEY" in config_script
         assert "HOMEBREW_TAP_DISPATCH_SECRET" in config_script
 
@@ -56,7 +56,7 @@ class TestPublishWorkflow:
             app_token_step["uses"]
             == "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349"
         )
-        assert app_token_step["with"]["app-id"] == "${{ env.HOMEBREW_TAP_APP_ID }}"
+        assert app_token_step["with"]["client-id"] == "${{ env.HOMEBREW_TAP_APP_CLIENT_ID }}"
         assert app_token_step["with"]["private-key"] == "${{ env.HOMEBREW_TAP_APP_PRIVATE_KEY }}"
         assert app_token_step["with"]["owner"] == "${{ env.HOMEBREW_TAP_REPOSITORY_OWNER }}"
         assert app_token_step["with"]["repositories"] == "${{ env.HOMEBREW_TAP_REPOSITORY_NAME }}"

--- a/tests/vstack/test_publish_workflow.py
+++ b/tests/vstack/test_publish_workflow.py
@@ -20,6 +20,8 @@ class TestPublishWorkflow:
         assert env["HOMEBREW_TAP_ENABLED"] == "false"
         assert env["HOMEBREW_TAP_NAME"] == "eschaar/vstack"
         assert env["HOMEBREW_TAP_REPOSITORY"] == "eschaar/homebrew-vstack"
+        assert env["HOMEBREW_TAP_REPOSITORY_OWNER"] == "eschaar"
+        assert env["HOMEBREW_TAP_REPOSITORY_NAME"] == "homebrew-vstack"
         assert env["HOMEBREW_FORMULA_NAME"] == "vstack"
         assert env["HOMEBREW_FULLY_QUALIFIED_FORMULA"] == "eschaar/vstack/vstack"
 
@@ -45,8 +47,19 @@ class TestPublishWorkflow:
             step for step in steps if step["name"] == "Verify Homebrew tap dispatch configuration"
         )
         config_script = config_step["run"]
-        assert "HOMEBREW_TAP_TOKEN" in config_script
+        assert "HOMEBREW_TAP_APP_ID" in config_script
+        assert "HOMEBREW_TAP_APP_PRIVATE_KEY" in config_script
         assert "HOMEBREW_TAP_DISPATCH_SECRET" in config_script
+
+        app_token_step = next(step for step in steps if step.get("id") == "create_tap_token")
+        assert (
+            app_token_step["uses"]
+            == "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349"
+        )
+        assert app_token_step["with"]["app-id"] == "${{ env.HOMEBREW_TAP_APP_ID }}"
+        assert app_token_step["with"]["private-key"] == "${{ env.HOMEBREW_TAP_APP_PRIVATE_KEY }}"
+        assert app_token_step["with"]["owner"] == "${{ env.HOMEBREW_TAP_REPOSITORY_OWNER }}"
+        assert app_token_step["with"]["repositories"] == "${{ env.HOMEBREW_TAP_REPOSITORY_NAME }}"
 
         dispatch_step = next(
             step for step in steps if step["name"] == "Dispatch formula update to Homebrew tap"
@@ -54,6 +67,7 @@ class TestPublishWorkflow:
         dispatch_script = dispatch_step["run"]
         assert "/dispatches" in dispatch_script
         assert "dispatch-body.json" in dispatch_script
+        assert "steps.create_tap_token.outputs.token" in dispatch_script
 
         step_env = dispatch_step["env"]
         assert step_env["RELEASE_VERSION"] == "${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Summary
- switch Homebrew publish job gating to repository variables for valid job-level evaluation
- enforce required Homebrew dispatch signing secret before dispatch execution
- migrate tap authentication from PAT to GitHub App token flow
- align app token inputs to client-id naming
- isolate Homebrew publish job in dedicated homebrew environment

## Why
- ensure workflow conditions are evaluated correctly at job level
- reduce credential risk by using short-lived GitHub App tokens instead of long-lived PATs
- fail fast when required signing configuration is missing
- separate Homebrew operational secrets from PyPI publish context for least-privilege handling

## Version impact
- [x] None
- [ ] Patch
- [ ] Minor
- [ ] Major