### PR TITLE
fix(ci): fix Homebrew token action for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Create Homebrew tap app token
         id: create_tap_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           client-id: ${{ env.HOMEBREW_TAP_APP_CLIENT_ID }}
           private-key: ${{ env.HOMEBREW_TAP_APP_PRIVATE_KEY }}

--- a/tests/vstack/test_publish_workflow.py
+++ b/tests/vstack/test_publish_workflow.py
@@ -54,7 +54,7 @@ class TestPublishWorkflow:
         app_token_step = next(step for step in steps if step.get("id") == "create_tap_token")
         assert (
             app_token_step["uses"]
-            == "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349"
+            == "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"
         )
         assert app_token_step["with"]["client-id"] == "${{ env.HOMEBREW_TAP_APP_CLIENT_ID }}"
         assert app_token_step["with"]["private-key"] == "${{ env.HOMEBREW_TAP_APP_PRIVATE_KEY }}"


### PR DESCRIPTION
## Summary
- update Homebrew token step in publish workflow to a create-github-app-token SHA that supports client-id
- align the publish workflow contract test with the new pin

## Why
- v3.5.0 publish failed in the Homebrew job because the previous pinned action revision did not accept client-id

## Version impact
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major