### PR TITLE
fix: update Homebrew formula to use PyYAML 6.0.3 and automate versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -246,9 +246,48 @@ jobs:
               print("ERROR: sha256 mismatch between PyPI metadata and downloaded tarball.", file=sys.stderr)
               sys.exit(1)
 
+          # Resolve the latest PyYAML release satisfying >=6.0.3.
+          def parse_ver(v):
+              try:
+                  return tuple(int(x) for x in v.split("."))
+              except ValueError:
+                  return (0,)
+
+          pyyaml_json_url = "https://pypi.org/pypi/PyYAML/json"
+          with urllib.request.urlopen(pyyaml_json_url) as response:
+              pyyaml_meta = json.load(response)
+
+          pyyaml_min = (6, 0, 3)
+          pyyaml_candidates = [
+              v for v in pyyaml_meta.get("releases", {})
+              if not any(c in v for c in ("a", "b", "rc", "dev"))
+              and parse_ver(v) >= pyyaml_min
+          ]
+          if not pyyaml_candidates:
+              print("ERROR: no PyYAML release satisfying >=6.0.3 found on PyPI.", file=sys.stderr)
+              sys.exit(1)
+
+          pyyaml_version = max(pyyaml_candidates, key=parse_ver)
+          pyyaml_release_assets = pyyaml_meta["releases"][pyyaml_version]
+          pyyaml_sdist = next(
+              (item for item in pyyaml_release_assets if item.get("packagetype") == "sdist"),
+              None,
+          )
+          if pyyaml_sdist is None:
+              print(f"ERROR: no sdist found for PyYAML {pyyaml_version}.", file=sys.stderr)
+              sys.exit(1)
+
+          pyyaml_url = pyyaml_sdist["url"]
+          pyyaml_sha = pyyaml_sdist.get("digests", {}).get("sha256", "")
+          if not pyyaml_sha:
+              print(f"ERROR: PyPI metadata did not provide a sha256 for PyYAML {pyyaml_version}.", file=sys.stderr)
+              sys.exit(1)
+
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write(f"sdist_url={sdist_url}\n")
               output.write(f"sdist_sha256={local_sha}\n")
+              output.write(f"pyyaml_url={pyyaml_url}\n")
+              output.write(f"pyyaml_sha256={pyyaml_sha}\n")
           PY
         env:
           GITHUB_REF_NAME: ${{ github.event.release.tag_name }}
@@ -259,6 +298,8 @@ jobs:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
           SDIST_URL: ${{ steps.verify_sdist.outputs.sdist_url }}
           SDIST_SHA256: ${{ steps.verify_sdist.outputs.sdist_sha256 }}
+          PYYAML_URL: ${{ steps.verify_sdist.outputs.pyyaml_url }}
+          PYYAML_SHA256: ${{ steps.verify_sdist.outputs.pyyaml_sha256 }}
         run: |
           python - <<'PY'
           import hmac
@@ -270,6 +311,8 @@ jobs:
               "version": os.environ["RELEASE_VERSION"],
               "sdist_url": os.environ["SDIST_URL"],
               "sha256": os.environ["SDIST_SHA256"],
+              "pyyaml_url": os.environ["PYYAML_URL"],
+              "pyyaml_sha256": os.environ["PYYAML_SHA256"],
           }
 
           secret = os.environ.get("HOMEBREW_TAP_DISPATCH_SECRET", "")

--- a/docs/architecture/homebrew-publish-plan.md
+++ b/docs/architecture/homebrew-publish-plan.md
@@ -120,8 +120,8 @@ class Vstack < Formula
   depends_on "python@3.11"
 
   resource "pyyaml" do
-    url "https://files.pythonhosted.org/packages/source/P/PyYAML/PyYAML-6.0.2.tar.gz"
-    sha256 "<sha256-of-pyyaml-sdist>"
+    url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+    sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
   end
 
   def install
@@ -244,11 +244,51 @@ jobs:
       - name: Update formula version and sha256
         shell: bash
         run: |
-          VERSION="${{ github.event.client_payload.version }}"
-          SHA256="${{ github.event.client_payload.sha256 }}"
-          URL="${{ github.event.client_payload.sdist_url }}"
-          sed -i "s|url \".*\"|url \"${URL}\"|" Formula/vstack.rb
-          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/vstack.rb
+          python3 - <<'PY'
+          import re
+          import os
+
+          url        = os.environ["SDIST_URL"]
+          sha256     = os.environ["SDIST_SHA256"]
+          pyyaml_url = os.environ["PYYAML_URL"]
+          pyyaml_sha = os.environ["PYYAML_SHA256"]
+
+          with open("Formula/vstack.rb") as f:
+              content = f.read()
+
+          # Replace top-level vstack sdist url (first url line only).
+          content = re.sub(
+              r'(^  url ")[^"]*(")' ,
+              rf'\g<1>{url}\2',
+              content, count=1, flags=re.MULTILINE,
+          )
+          # Replace top-level vstack sha256 (first sha256 line only).
+          content = re.sub(
+              r'^  sha256 "[0-9a-f]+"',
+              f'  sha256 "{sha256}"',
+              content, count=1, flags=re.MULTILINE,
+          )
+          # Replace pyyaml resource url.
+          content = re.sub(
+              r'(resource "pyyaml" do\n    url ")[^"]*(")' ,
+              rf'\g<1>{pyyaml_url}\2',
+              content,
+          )
+          # Replace pyyaml resource sha256.
+          content = re.sub(
+              r'(resource "pyyaml" do\n    url "[^"]*"\n    sha256 ")[0-9a-f]+(")',
+              rf'\g<1>{pyyaml_sha}\2',
+              content,
+          )
+
+          with open("Formula/vstack.rb", "w") as f:
+              f.write(content)
+          PY
+        env:
+          SDIST_URL: ${{ github.event.client_payload.sdist_url }}
+          SDIST_SHA256: ${{ github.event.client_payload.sha256 }}
+          PYYAML_URL: ${{ github.event.client_payload.pyyaml_url }}
+          PYYAML_SHA256: ${{ github.event.client_payload.pyyaml_sha256 }}
       - name: Commit and push
         run: |
           git config user.name "vstack-release-bot"


### PR DESCRIPTION
Hi,

I've been investigating a Homebrew install failure that affects anyone who tries brew tap eschaar/vstack && brew install vstack today. Here's the full picture and what needs to change on your end.

What's broken and why

brew install vstack currently fails with:

The root cause is in Formula/vstack.rb in this repo (eschaar/homebrew-vstack). The pyyaml resource block was committed with empty url and sha256 values:

Homebrew cannot install a resource with no URL, so the install fails immediately.

This happened because the automated dispatch from vstack/publish.yml was never enabled (HOMEBREW_TAP_ENABLED was "false"), so the formula was manually seeded but with placeholder values that were never filled in.

Fix 1 — immediate: patch Formula/vstack.rb (one manual commit to this repo)

Replace the pyyaml resource block with the correct PyYAML 6.0.3 values (latest stable, satisfies the >=6.0 constraint in vstack's [pyproject.toml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)):

This is the only change needed to unblock installs today.

Fix 2 — structural: replace the formula-update.yml update step (one commit to this repo)

There's a second bug that will cause the same problem again on the next automated release. The current formula-update.yml uses sed patterns that match every url "..." and sha256 "..." line in the file — including the ones inside the pyyaml resource block. So every automated formula update overwrites the pyyaml values with the vstack sdist values.

Replace the update step with this Python-based approach, which is precise and safe:

The count=1 ensures only the first match (the top-level formula block) is touched, and the resource-scoped patterns update pyyaml independently without any risk of collision.


Summary of what you need to do

Step	Repo	Change
Fix broken install now	eschaar/homebrew-vstack	Update pyyaml resource block in Formula/vstack.rb (Fix 1)
Prevent recurrence	eschaar/homebrew-vstack	Replace sed update step in formula-update.yml (Fix 2)
Enable automation	eschaar/vstack	Merge the [publish.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) PR and set HOMEBREW_TAP_ENABLED = "true"